### PR TITLE
Feat#11 조회수

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'com.redis:testcontainers-redis:2.2.2'
 
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,8 +51,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-
-    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,14 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'com.redis:testcontainers-redis:2.2.2'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/org/juniortown/backend/BackendApplication.java
+++ b/backend/src/main/java/org/juniortown/backend/BackendApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/org/juniortown/backend/config/RedisConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package org.juniortown.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String host;
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Boolean> keyCheckRedisTemplate() {
+		RedisTemplate<String,Boolean> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedisTemplate<String, Long> readCountRedisTemplate() {
+		RedisTemplate<String,Long> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
 		//경로별 인가 작업
 		http
 			.authorizeHttpRequests((auth) -> auth
-				.requestMatchers("/api/auth/login", "/", "/api/auth/signup","/swagger-ui/**","/v3/api-docs/**").permitAll()
+				.requestMatchers("/api/auth/login", "/", "/api/auth/signup","/swagger-ui/**","/v3/api-docs/**","/api/posts/details/**").permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 

--- a/backend/src/main/java/org/juniortown/backend/config/WebMvcConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/WebMvcConfig.java
@@ -1,9 +1,23 @@
 package org.juniortown.backend.config;
 
+import org.juniortown.backend.interceptor.GuestCookieInterceptor;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+	private final GuestCookieInterceptor guestCookieInterceptor;
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(guestCookieInterceptor)
+			.addPathPatterns("/**");
+	}
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")

--- a/backend/src/main/java/org/juniortown/backend/interceptor/GuestCookieInterceptor.java
+++ b/backend/src/main/java/org/juniortown/backend/interceptor/GuestCookieInterceptor.java
@@ -1,0 +1,36 @@
+package org.juniortown.backend.interceptor;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class GuestCookieInterceptor implements HandlerInterceptor {
+	private static final String COOKIE_NAME = "guestId";
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		Cookie[] cookies = request.getCookies();
+		boolean hasGuestId = false;
+		if (cookies != null) {
+			for(Cookie c : cookies) {
+				if (COOKIE_NAME.equals(c.getName())) {
+					hasGuestId = true;
+					break;
+				}
+			}
+		}
+		if(!hasGuestId) {
+			String guestId = UUID.randomUUID().toString();
+			Cookie cookie = new Cookie(COOKIE_NAME, guestId);
+			cookie.setPath("/");
+			cookie.setMaxAge(60 * 60 * 24 * 365); // 1 year
+			response.addCookie(cookie);
+		}
+		return true;
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/interceptor/GuestCookieInterceptor.java
+++ b/backend/src/main/java/org/juniortown/backend/interceptor/GuestCookieInterceptor.java
@@ -28,7 +28,8 @@ public class GuestCookieInterceptor implements HandlerInterceptor {
 			String guestId = UUID.randomUUID().toString();
 			Cookie cookie = new Cookie(COOKIE_NAME, guestId);
 			cookie.setPath("/");
-			cookie.setMaxAge(60 * 60 * 24 * 365); // 1 year
+			cookie.setMaxAge(60 * 60 * 24 * 15); // 15 days
+			cookie.setHttpOnly(true);
 			response.addCookie(cookie);
 		}
 		return true;

--- a/backend/src/main/java/org/juniortown/backend/like/repository/LikeRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/like/repository/LikeRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 	Optional<Like> findByUserIdAndPostId(Long userId, Long postId);
+	Long countByPostId(Long postId);
 }

--- a/backend/src/main/java/org/juniortown/backend/like/service/LikeService.java
+++ b/backend/src/main/java/org/juniortown/backend/like/service/LikeService.java
@@ -34,7 +34,7 @@ public class LikeService {
 					.post(post)
 					.build();
 				likeRepository.save(newLike);
-				
+
 				return LikeResponse.builder()
 					.userId(userId)
 					.postId(postId)

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -76,7 +76,7 @@ public class PostController {
 		if(customUserDetails == null) {
 			// 비회원인 경우
 			// 쿠키값을 레디스에 등록
-			viewCountService.readCountUp(guestId, String.valueOf(postId));
+			redisReadCount = viewCountService.readCountUp(guestId, String.valueOf(postId));
 		} else {
 			// 회원인 경우
 			// userId,postId를 조합해서 레디스에 등록

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -72,7 +72,7 @@ public class PostController {
 		,@PathVariable Long postId
 		,@CookieValue(value = "guestId", required = false) String guestId
 	) {
-		PostResponse postResponse = postService.getPost(postId);
+		Long redisReadCount = 0L;
 		if(customUserDetails == null) {
 			// 비회원인 경우
 			// 쿠키값을 레디스에 등록
@@ -81,8 +81,11 @@ public class PostController {
 			// 회원인 경우
 			// userId,postId를 조합해서 레디스에 등록
 			Long userId = customUserDetails.getUserId();
-			viewCountService.readCountUp(String.valueOf(userId), String.valueOf(postId));
+			redisReadCount = viewCountService.readCountUp(String.valueOf(userId), String.valueOf(postId));
 		}
+
+		PostResponse postResponse = postService.getPost(postId);
+		postResponse.addReadCount(redisReadCount);
 		return ResponseEntity.ok(postResponse);
 	}
 

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -83,8 +83,6 @@ public class PostController {
 			Long userId = customUserDetails.getUserId();
 			viewCountService.readCountUp(String.valueOf(userId), String.valueOf(postId));
 		}
-
-
 		return ResponseEntity.ok(postResponse);
 	}
 

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -4,6 +4,7 @@ import java.util.stream.Collectors;
 
 import org.juniortown.backend.post.dto.request.PostCreateRequest;
 import org.juniortown.backend.post.dto.response.PageResponse;
+import org.juniortown.backend.post.dto.response.PostDetailResponse;
 import org.juniortown.backend.post.dto.response.PostWithLikeCount;
 import org.juniortown.backend.post.dto.response.PostResponse;
 import org.juniortown.backend.post.dto.response.PostWithLikeCountProjection;
@@ -70,7 +71,7 @@ public class PostController {
 	}
 
 	@GetMapping("/posts/details/{postId}")
-	public ResponseEntity<PostResponse> getPost(@AuthenticationPrincipal CustomUserDetails customUserDetails
+	public ResponseEntity<PostDetailResponse> getPost(@AuthenticationPrincipal CustomUserDetails customUserDetails
 		,@PathVariable Long postId
 		,@CookieValue(value = "guestId", required = false) String guestId
 	) {
@@ -86,9 +87,9 @@ public class PostController {
 			redisReadCount = viewCountService.readCountUp(String.valueOf(userId), String.valueOf(postId));
 		}
 
-		PostResponse postResponse = postService.getPost(postId);
-		postResponse.addReadCount(redisReadCount);
-		return ResponseEntity.ok(postResponse);
+		PostDetailResponse postDetailResponse = postService.getPost(postId);
+		postDetailResponse.addReadCount(redisReadCount);
+		return ResponseEntity.ok(postDetailResponse);
 	}
 
 }

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -1,5 +1,7 @@
 package org.juniortown.backend.post.controller;
 
+import java.util.stream.Collectors;
+
 import org.juniortown.backend.post.dto.request.PostCreateRequest;
 import org.juniortown.backend.post.dto.response.PageResponse;
 import org.juniortown.backend.post.dto.response.PostWithLikeCount;
@@ -58,12 +60,12 @@ public class PostController {
 
 	// 게시글 목록 조회, 페이지네이션 적용
 	@GetMapping("/posts/{page}")
-	public ResponseEntity<PageResponse<PostWithLikeCountProjection>> getPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable int page) {
+	public ResponseEntity<PageResponse<PostResponse>> getPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable int page) {
 		Long userId = customUserDetails.getUserId();
 		// null체크
 
-	 	Page<PostWithLikeCountProjection> posts = postService.getPosts(userId, page);
-		PageResponse<PostWithLikeCountProjection> response = new PageResponse<>(posts);
+	 	Page<PostResponse> posts = postService.getPosts(userId, page);
+		PageResponse<PostResponse> response = new PageResponse<>(posts);
 		return ResponseEntity.ok(response);
 	}
 

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -75,20 +75,8 @@ public class PostController {
 		,@PathVariable Long postId
 		,@CookieValue(value = "guestId", required = false) String guestId
 	) {
-		Long redisReadCount = 0L;
-		if(customUserDetails == null) {
-			// 비회원인 경우
-			// 쿠키값을 레디스에 등록
-			redisReadCount = viewCountService.readCountUp(guestId, String.valueOf(postId));
-		} else {
-			// 회원인 경우
-			// userId,postId를 조합해서 레디스에 등록
-			Long userId = customUserDetails.getUserId();
-			redisReadCount = viewCountService.readCountUp(String.valueOf(userId), String.valueOf(postId));
-		}
-
-		PostDetailResponse postDetailResponse = postService.getPost(postId);
-		postDetailResponse.addReadCount(redisReadCount);
+		String viewerId = customUserDetails != null ? String.valueOf(customUserDetails.getUserId()) : guestId;
+		PostDetailResponse postDetailResponse = postService.getPost(postId, viewerId);
 		return ResponseEntity.ok(postDetailResponse);
 	}
 

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostDetailResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,55 @@
+package org.juniortown.backend.post.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostDetailResponse {
+	private Long id;
+	private String title;
+	private String content;
+	private Long userId;
+	private String userName;
+	private Long likeCount;
+	private Boolean isLiked;
+	private Long readCount;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public PostDetailResponse(Long id, String title, String content, Long userId, String userName, Long likeCount,
+			Boolean isLiked, Long readCount, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.userId = userId;
+		this.userName = userName;
+		this.likeCount = likeCount;
+		this.isLiked = isLiked;
+		this.readCount = readCount;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.deletedAt = deletedAt;
+	}
+	public static PostDetailResponse from(PostResponse postResponse) {
+		return PostDetailResponse.builder()
+			.id(postResponse.getId())
+			.title(postResponse.getTitle())
+			.content(postResponse.getContent())
+			.userId(postResponse.getUserId())
+			.userName(postResponse.getUserName())
+			.likeCount(postResponse.getLikeCount())
+			.isLiked(postResponse.getIsLiked())
+			.readCount(postResponse.getReadCount())
+			.createdAt(postResponse.getCreatedAt())
+			.updatedAt(postResponse.getUpdatedAt())
+			.deletedAt(postResponse.getDeletedAt())
+			.build();
+	}
+	public void addReadCount(Long redisReadCount) {
+		this.readCount += redisReadCount;
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostDetailResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostDetailResponse.java
@@ -7,17 +7,17 @@ import lombok.Getter;
 
 @Getter
 public class PostDetailResponse {
-	private Long id;
-	private String title;
-	private String content;
-	private Long userId;
-	private String userName;
-	private Long likeCount;
-	private Boolean isLiked;
-	private Long readCount;
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
-	private LocalDateTime deletedAt;
+	private final Long id;
+	private final String title;
+	private final String content;
+	private final Long userId;
+	private final String userName;
+	private final Long likeCount;
+	private final Boolean isLiked;
+	private final Long readCount;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+	private final LocalDateTime deletedAt;
 
 	@Builder
 	public PostDetailResponse(Long id, String title, String content, Long userId, String userName, Long likeCount,
@@ -48,8 +48,5 @@ public class PostDetailResponse {
 			.updatedAt(postResponse.getUpdatedAt())
 			.deletedAt(postResponse.getDeletedAt())
 			.build();
-	}
-	public void addReadCount(Long redisReadCount) {
-		this.readCount += redisReadCount;
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
@@ -16,8 +16,8 @@ public class PostResponse {
 	private final Long userId;
 	private final String userName;
 	private final Long likeCount;
-	private Long readCount;
-	private Boolean isLiked;
+	private final Long readCount;
+	private final Boolean isLiked;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final LocalDateTime deletedAt;
@@ -44,6 +44,8 @@ public class PostResponse {
 			.content(post.getContent())
 			.userId(post.getUser().getId())
 			.userName(post.getUser().getName())
+			.likeCount(0L) // 기본값 넣어주기
+			.isLiked(false) // 기본값 넣어주기
 			.readCount(post.getReadCount())
 			.createdAt(post.getCreatedAt())
 			.updatedAt(post.getUpdatedAt())

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.juniortown.backend.post.entity.Post;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -13,24 +14,40 @@ public class PostResponse {
 	private final String content;
 	private final Long userId;
 	private final String userName;
-	//private final Long likeCount;
+	private final Long likeCount;
 	private Long readCount;
+	private Boolean isLiked;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final LocalDateTime deletedAt;
 
-	public PostResponse(Post post) {
-		this.id = post.getId();
-		this.title = post.getTitle();
-		this.content = post.getContent();
-		this.userId = post.getUser().getId();
-		this.userName = post.getUser().getName();
-		// this.likeCount = post.getLikeCount();
-		// 좋아요 수 집계함수로 컬럼으로 만들까?
-		this.readCount = post.getReadCount();
-		this.createdAt = post.getCreatedAt();
-		this.updatedAt = post.getUpdatedAt();
-		this.deletedAt = post.getDeletedAt();
+	@Builder
+	public PostResponse(Long id, String title, String content, Long userId, String userName, Long likeCount,
+			Boolean isLiked, Long readCount, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.userId = userId;
+		this.userName = userName;
+		this.likeCount = likeCount;
+		this.isLiked = isLiked;
+		this.readCount = readCount;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.deletedAt = deletedAt;
+	}
+	public static PostResponse from(Post post) {
+		return PostResponse.builder()
+			.id(post.getId())
+			.title(post.getTitle())
+			.content(post.getContent())
+			.userId(post.getUser().getId())
+			.userName(post.getUser().getName())
+			.readCount(post.getReadCount())
+			.createdAt(post.getCreatedAt())
+			.updatedAt(post.getUpdatedAt())
+			.deletedAt(post.getDeletedAt())
+			.build();
 	}
 
 	public void addReadCount(Long redisRedaCount) {

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
@@ -13,6 +13,8 @@ public class PostResponse {
 	private final String content;
 	private final Long userId;
 	private final String userName;
+	//private final Long likeCount;
+	private Long readCount;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final LocalDateTime deletedAt;
@@ -23,8 +25,15 @@ public class PostResponse {
 		this.content = post.getContent();
 		this.userId = post.getUser().getId();
 		this.userName = post.getUser().getName();
+		// this.likeCount = post.getLikeCount();
+		// 좋아요 수 집계함수로 컬럼으로 만들까?
+		this.readCount = post.getReadCount();
 		this.createdAt = post.getCreatedAt();
 		this.updatedAt = post.getUpdatedAt();
 		this.deletedAt = post.getDeletedAt();
+	}
+
+	public void addReadCount(Long redisRedaCount) {
+		this.readCount += redisRedaCount;
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostResponse.java
@@ -6,6 +6,7 @@ import org.juniortown.backend.post.entity.Post;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class PostResponse {
@@ -48,9 +49,5 @@ public class PostResponse {
 			.updatedAt(post.getUpdatedAt())
 			.deletedAt(post.getDeletedAt())
 			.build();
-	}
-
-	public void addReadCount(Long redisRedaCount) {
-		this.readCount += redisRedaCount;
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostWithLikeCountProjection.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostWithLikeCountProjection.java
@@ -2,6 +2,7 @@ package org.juniortown.backend.post.dto.response;
 
 import java.time.LocalDateTime;
 
+
 public interface PostWithLikeCountProjection {
 	Long getId();
 	String getTitle();

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostWithLikeCountProjection.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostWithLikeCountProjection.java
@@ -9,6 +9,7 @@ public interface PostWithLikeCountProjection {
 	Long getUserId();
 	Long getLikeCount();
 	Boolean getIsLiked();
+	Long getReadCount();
 	LocalDateTime getCreatedAt();
 	LocalDateTime getUpdatedAt();
 }

--- a/backend/src/main/java/org/juniortown/backend/post/entity/Post.java
+++ b/backend/src/main/java/org/juniortown/backend/post/entity/Post.java
@@ -40,6 +40,9 @@ public class Post extends BaseTimeEntity {
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 
+	@Column(name = "read_count", nullable = false)
+	private Long readCount = 0L;
+
 	@Builder
 	public Post(String title, String content, User user) {
 		this.title = title;

--- a/backend/src/main/java/org/juniortown/backend/post/entity/Post.java
+++ b/backend/src/main/java/org/juniortown/backend/post/entity/Post.java
@@ -52,7 +52,6 @@ public class Post extends BaseTimeEntity {
 
 	public void softDelete(Clock clock) {
 		this.deletedAt = LocalDateTime.now(clock);
-
 	}
 
 	public void update(PostCreateRequest postCreateRequest, Clock clock) {

--- a/backend/src/main/java/org/juniortown/backend/post/entity/Post.java
+++ b/backend/src/main/java/org/juniortown/backend/post/entity/Post.java
@@ -58,4 +58,8 @@ public class Post extends BaseTimeEntity {
 		this.title = postCreateRequest.getTitle();
 		this.content = postCreateRequest.getContent();
 	}
+
+	public void addReadCount(Long redisReadCount) {
+		this.readCount += redisReadCount;
+	}
 }

--- a/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import org.juniortown.backend.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;

--- a/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
@@ -15,7 +15,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 	Page<Post> findAllByDeletedAtIsNull(Pageable pageable);
 
 	@Query(
-		"SELECT p.id AS id, p.title AS title, u.name AS username, u.id AS userId, COUNT(l.id) AS likeCount, " +
+		"SELECT p.id AS id, p.title AS title, p.readCount AS readCount, u.name AS username, u.id AS userId, COUNT(l.id) AS likeCount, " +
 			"p.createdAt AS createdAt, p.updatedAt AS updatedAt, " +
 			"CASE WHEN EXISTS (" +
 			"   SELECT 1 FROM Like l2 WHERE l2.post.id = p.id AND l2.user.id = :userId" +
@@ -24,7 +24,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 			"JOIN p.user u " +
 			"LEFT JOIN Like l ON l.post.id = p.id " +
 			"WHERE p.deletedAt IS NULL " +
-			"GROUP BY p.id, p.title, u.name, u.id, p.createdAt, p.updatedAt, p.deletedAt"
+			"GROUP BY p.id, p.title, p.readCount, u.name, u.id, p.createdAt, p.updatedAt, p.deletedAt"
 	)
 	Page<PostWithLikeCountProjection> findAllWithLikeCount(@Param("userId") Long userId, Pageable pageable);
 

--- a/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
@@ -27,7 +27,7 @@ public class ViewCountService {
 
 	public Long readCountUp(String userId, String postId) {
 		String dupKey = DUP_PREVENT_KEY + postId + ":" + userId;
-		String readCountKey = VIEW_COUNT_KEY + postId + ":" + userId;
+		String readCountKey = VIEW_COUNT_KEY + postId;
 		// dupKey 조회
 		Boolean exist = keyCheckRedisTemplate.opsForValue().get(dupKey);
 		if (exist != null && exist) {

--- a/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
@@ -25,8 +25,9 @@ public class ViewCountService {
 	private static final String DUP_PREVENT_KEY = "postDup:key:";
 
 
-	public void readCountUp(String userId, String postId) {
+	public Long readCountUp(String userId, String postId) {
 		String dupKey = DUP_PREVENT_KEY + postId + ":" + userId;
+		String readCountKey = VIEW_COUNT_KEY + postId + ":" + userId;
 		// dupKey 조회
 		Boolean exist = keyCheckRedisTemplate.opsForValue().get(dupKey);
 		if (exist != null && exist) {
@@ -35,10 +36,10 @@ public class ViewCountService {
 		}else{
 			// 중복키 생성
 			keyCheckRedisTemplate.opsForValue().set(dupKey,true, 10, TimeUnit.MINUTES);
-
-			// 조회수증분키에 조회수 1증가
-			String readCountKey = VIEW_COUNT_KEY + postId + ":" + userId;
+			// 조회수 증분키에 조회수 1증가
 			readCountRedisTemplate.opsForValue().increment(readCountKey);
 		}
+		Long readCount = readCountRedisTemplate.opsForValue().get(readCountKey);
+		return readCount != null ? readCount : 0L;
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
@@ -24,22 +24,41 @@ public class ViewCountService {
 	// 중복방지키 형태, postDup:key:{postId}:{userId}
 	public static final String DUP_PREVENT_KEY = "postDup:key:";
 
-
 	public Long readCountUp(String userId, String postId) {
-		String dupKey = DUP_PREVENT_KEY + postId + ":" + userId;
-		String readCountKey = VIEW_COUNT_KEY + postId;
-		// dupKey 조회
-		Boolean exist = keyCheckRedisTemplate.opsForValue().get(dupKey);
-		if (exist != null && exist) {
-			// 10분이 지나지 않았으니 조회수가 늘지 않는다.
-			log.info("이미 최근에 조회한 게시글 - 게시글 카운트 증가 x");
-		}else{
-			// 중복키 생성
-			keyCheckRedisTemplate.opsForValue().set(dupKey,true, 10, TimeUnit.MINUTES);
-			// 조회수 증분키에 조회수 1증가
-			readCountRedisTemplate.opsForValue().increment(readCountKey);
+		String dupKey = buildDupPreventKey(postId, userId);
+		String readCountKey = buildReadCountKey(postId);
+		try {
+			// dupKey 조회
+			Boolean exist = keyCheckRedisTemplate.opsForValue().get(dupKey);
+			if (exist != null && exist) {
+				// 10분이 지나지 않았으니 조회수가 늘지 않는다.
+				log.info("이미 최근에 조회한 게시글 - 게시글 카운트 증가 x");
+				return getReadCount(postId);
+			} else {
+				// 중복키 생성
+				keyCheckRedisTemplate.opsForValue().set(dupKey, true, 10, TimeUnit.MINUTES);
+				// 조회수 캐시++1
+				readCountRedisTemplate.opsForValue().increment(readCountKey);
+				return getReadCount(postId);
+			}
+		} catch (Exception e) {
+			log.error("Redis 조회수 처리 중 오류 발생: postId={}, userId={}", postId, userId, e);
+			// 예외 발생 시에도 조회수는 0으로 반환
+			return 0L;
 		}
+	}
+
+	public Long getReadCount(String postId) {
+		String readCountKey = buildReadCountKey(postId);
 		Long readCount = readCountRedisTemplate.opsForValue().get(readCountKey);
 		return readCount != null ? readCount : 0L;
+	}
+
+	private String buildDupPreventKey(String postId, String userId) {
+		return DUP_PREVENT_KEY + postId + ":" + userId;
+	}
+
+	private String buildReadCountKey(String postId) {
+		return VIEW_COUNT_KEY + postId;
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/ViewCountService.java
@@ -20,9 +20,9 @@ public class ViewCountService {
 	@Qualifier("readCountRedisTemplate")
 	private final RedisTemplate<String, Long> readCountRedisTemplate;
 	// 조회수증분키 형태, post:viewCount:{postId}:{userId}
-	private static final String VIEW_COUNT_KEY = "post:viewCount:";
+	public static final String VIEW_COUNT_KEY = "post:viewCount:";
 	// 중복방지키 형태, postDup:key:{postId}:{userId}
-	private static final String DUP_PREVENT_KEY = "postDup:key:";
+	public static final String DUP_PREVENT_KEY = "postDup:key:";
 
 
 	public Long readCountUp(String userId, String postId) {

--- a/backend/src/main/java/org/juniortown/backend/post/service/ViewCountSyncService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/ViewCountSyncService.java
@@ -27,6 +27,7 @@ public class ViewCountSyncService {
 
 	@Scheduled(fixedDelay = 5 * 60 * 1000) // 5분마다 실행
 	public void syncViewCounts() {
+		log.info("ViewCountSyncService.syncViewCounts() - 시작");
 		RLock lock = redissonClient.getLock(SYNC_LOCK_KEY);
 		boolean available = false;
 		try {

--- a/backend/src/main/java/org/juniortown/backend/post/service/ViewCountSyncService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/ViewCountSyncService.java
@@ -1,0 +1,57 @@
+package org.juniortown.backend.post.service;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.post.repository.PostRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ViewCountSyncService {
+	private final RedisTemplate<String, Long> redisTemplate;
+	private final PostRepository postRepository;
+	private final RedissonClient redissonClient;
+	public static final String SYNC_LOCK_KEY = "sync:viewCount:lock";
+
+	@Scheduled(fixedDelay = 5 * 60 * 1000) // 5분마다 실행
+	public void syncViewCounts() {
+		RLock lock = redissonClient.getLock(SYNC_LOCK_KEY);
+		boolean available = false;
+		try {
+			available = lock.tryLock(10, 300, TimeUnit.SECONDS);
+			if(!available){
+				log.info("동기화 락을 획득하지 못했습니다. 다른 인스턴스에세 이미 실행 중입니다.");
+				return;
+			}
+			Set<String> keys = redisTemplate.keys("post:viewCount:*");
+			if(keys == null) return;
+			for (String key : keys) {
+				Long postId = Long.valueOf(key.split(":")[2]);
+				Long count = redisTemplate.opsForValue().get(key);
+				if(count == null || count == 0) continue;
+
+				postRepository.findById(postId).ifPresent(post -> {
+					post.addReadCount(post.getReadCount() + count);
+				});
+				redisTemplate.delete(key);
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		} finally {
+			if(available) lock.unlock();
+		}
+	}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
       pageable:
         one-indexed-parameters: true
         default-page-size: 5
+
+    redis:
+      host: localhost
+      port: 6379
   sql:
     init:
       mode: always
@@ -24,5 +28,8 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET_KEY}
+
+
+
 
 

--- a/backend/src/test/java/org/juniortown/backend/config/RedisTestConfig.java
+++ b/backend/src/test/java/org/juniortown/backend/config/RedisTestConfig.java
@@ -1,6 +1,9 @@
 package org.juniortown.backend.config;
 
+import org.juniortown.backend.post.service.ViewCountSyncService;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/test/java/org/juniortown/backend/config/RedisTestConfig.java
+++ b/backend/src/test/java/org/juniortown/backend/config/RedisTestConfig.java
@@ -1,13 +1,8 @@
 package org.juniortown.backend.config;
 
-import org.juniortown.backend.post.service.ViewCountSyncService;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;

--- a/backend/src/test/java/org/juniortown/backend/config/RedisTestConfig.java
+++ b/backend/src/test/java/org/juniortown/backend/config/RedisTestConfig.java
@@ -1,6 +1,8 @@
 package org.juniortown.backend.config;
 
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -10,34 +12,33 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-@Configuration
-@Profile("!test") // test 프로파일이 아닐 때만 활성화
-public class RedisConfig {
+@TestConfiguration
+@Profile("test")
+public class RedisTestConfig {
 	@Value("${spring.data.redis.host}")
 	private String host;
 	@Value("${spring.data.redis.port}")
 	private int port;
-
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		return new LettuceConnectionFactory(host,port); // host/port는 properties에서 spring이 읽어감
 	}
-
 	@Bean
 	public RedisTemplate<String, Boolean> keyCheckRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
 		RedisTemplate<String,Boolean> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		return redisTemplate;
 	}
 
 	@Bean
 	public RedisTemplate<String, Long> readCountRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
 		RedisTemplate<String,Long> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Long.class));
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		return redisTemplate;
 	}
 }
+

--- a/backend/src/test/java/org/juniortown/backend/config/SyncConfig.java
+++ b/backend/src/test/java/org/juniortown/backend/config/SyncConfig.java
@@ -1,0 +1,17 @@
+package org.juniortown.backend.config;
+
+import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
+@TestConfiguration
+@Profile("test")
+public class SyncConfig {
+	@Bean
+	public RedissonClient redissonClient() {
+		// 테스트용 Mock 객체 반환 (실제 Redis 연결 X)
+		return Mockito.mock(RedissonClient.class);
+	}
+}

--- a/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.config.SyncConfig;
 import org.juniortown.backend.user.dto.LoginDTO;
-import org.juniortown.backend.user.entity.User;
 import org.juniortown.backend.user.jwt.JWTUtil;
 import org.juniortown.backend.user.repository.UserRepository;
 import org.juniortown.backend.user.request.SignUpDTO;
@@ -21,15 +20,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest

--- a/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.user.dto.LoginDTO;
 import org.juniortown.backend.user.entity.User;
 import org.juniortown.backend.user.jwt.JWTUtil;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -32,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Import(RedisTestConfig.class)
 class AuthControllerTest {
 	@Autowired
 	private MockMvc mockMvc;

--- a/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.juniortown.backend.config.RedisTestConfig;
+import org.juniortown.backend.config.SyncConfig;
 import org.juniortown.backend.user.dto.LoginDTO;
 import org.juniortown.backend.user.entity.User;
 import org.juniortown.backend.user.jwt.JWTUtil;
@@ -34,7 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import(RedisTestConfig.class)
+@Import({RedisTestConfig.class,SyncConfig.class})
 class AuthControllerTest {
 	@Autowired
 	private MockMvc mockMvc;

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
@@ -140,6 +140,15 @@ public class PostControllerPagingTest {
 			.andExpect(jsonPath("$.hasPrevious").value(false))
 			.andExpect(jsonPath("$.hasNext").value(true)) // 다음 페이지 있음
 			.andExpect(jsonPath("$.page").value(0)) // 현재 페이지
+			.andExpect(jsonPath("$.content[0].id").value(53))
+			.andExpect(jsonPath("$.content[0].title").value("테스트 글 53")) // 첫 번째 게시글 제목
+			.andExpect(jsonPath("$.content[0].userId").value(testUser1.getId())) // 첫 번째 게시글 작성자 ID
+			.andExpect(jsonPath("$.content[0].userName").value(testUser1.getName())) // 첫 번째 게시글 작성자 이름
+			.andExpect(jsonPath("$.content[0].likeCount").value(0)) // 첫 번째 게시글 좋아요 수
+			.andExpect(jsonPath("$.content[0].readCount").value(0)) // 첫 번째 게시글 조회수
+			.andExpect(jsonPath("$.content[0].createdAt").exists()) // 첫 번째 게시글 생성일시
+			.andExpect(jsonPath("$.content[0].updatedAt").exists()) // 첫 번째 게시글 수정일시
+			.andExpect(jsonPath("$.content[0].isLiked").value(false)) // 첫 번째 게시글 좋아요 여부
 			.andDo(print());
 	}
 

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
@@ -9,6 +9,7 @@ import java.time.Clock;
 import java.util.List;
 import java.util.UUID;
 
+import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.like.entity.Like;
 import org.juniortown.backend.like.repository.LikeRepository;
 import org.juniortown.backend.like.service.LikeService;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,6 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ActiveProfiles("test")
+@Import(RedisTestConfig.class)
 @Transactional
 public class PostControllerPagingTest {
 	@Autowired

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.juniortown.backend.config.RedisTestConfig;
+import org.juniortown.backend.config.SyncConfig;
 import org.juniortown.backend.like.entity.Like;
 import org.juniortown.backend.like.repository.LikeRepository;
 import org.juniortown.backend.like.service.LikeService;
@@ -45,7 +46,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ActiveProfiles("test")
-@Import(RedisTestConfig.class)
+@Import({RedisTestConfig.class, SyncConfig.class})
 @Transactional
 public class PostControllerPagingTest {
 	@Autowired

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.juniortown.backend.config.RedisTestConfig;
+import org.juniortown.backend.config.SyncConfig;
 import org.juniortown.backend.post.dto.request.PostCreateRequest;
 import org.juniortown.backend.post.entity.Post;
 import org.juniortown.backend.post.repository.PostRepository;
@@ -55,7 +56,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ActiveProfiles("test")
-@Import(RedisTestConfig.class)
+@Import({RedisTestConfig.class, SyncConfig.class})
 @Transactional
 class PostControllerTest {
 	@Autowired

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.post.dto.request.PostCreateRequest;
 import org.juniortown.backend.post.entity.Post;
 import org.juniortown.backend.post.repository.PostRepository;
@@ -36,6 +37,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -53,6 +55,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ActiveProfiles("test")
+@Import(RedisTestConfig.class)
 @Transactional
 class PostControllerTest {
 	@Autowired
@@ -436,47 +439,4 @@ class PostControllerTest {
 			.andExpect(jsonPath("$.validation.content").value("컨텐츠를 입력해주세요."))
 			.andDo(print());
 	}
-
-	@Test
-	@DisplayName("글 상세 조회 성공")
-	void getPostDetail_success() throws Exception {
-		// given
-		Post post = Post.builder()
-			.user(testUser)
-			.title("테스트 글")
-			.content("테스트 내용")
-			.build();
-
-		Post savePost = postRepository.save(post);
-		Long postId = savePost.getId();
-
-
-		// expected
-		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/details/{postId}", postId)
-				.contentType(APPLICATION_JSON)
-				.header("Authorization", jwt)
-			)
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.content").value("테스트 내용"))
-			.andDo(print());
-	}
-
-	@Test
-	@DisplayName("글 상세 조회 실패 - 존재하지 않는 게시글")
-	void getPostDetail_nonExistPost_failure() throws Exception {
-		// given
-		Long postId = 0L;
-
-		// expected
-		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/details/{postId}" ,postId)
-				.contentType(APPLICATION_JSON)
-				.header("Authorization", jwt)
-			)
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("$.code").value("404"))
-			.andExpect(jsonPath("$.message").value("해당 게시글을 찾을 수 없습니다."))
-			.andDo(print());
-	}
-
-
 }

--- a/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
@@ -81,8 +81,6 @@ public class PostRedisReadControllerTest {
 
 	@DynamicPropertySource
 	static void overrideProps(DynamicPropertyRegistry registry) {
-		System.out.println("Redis 컨테이너 IP: " + redis.getHost());
-		System.out.println("Redis 컨테이너 포트: " + redis.getMappedPort(6380));
 		registry.add("spring.data.redis.host", redis::getHost);
 		registry.add("spring.data.redis.port", () -> redis.getFirstMappedPort());
 	}

--- a/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
@@ -188,7 +188,14 @@ public class PostRedisReadControllerTest {
 			.andExpect(status().isOk())
 			.andDo(print())
 			.andExpect(jsonPath("$.content").value("테스트 내용"))
-			.andExpect(jsonPath("$.readCount").value(1));
+			.andExpect(jsonPath("$.readCount").value(1))
+			.andExpect(jsonPath("$.userId").value(testUser.getId()))
+			.andExpect(jsonPath("$.userName").value(testUser.getName()))
+			.andExpect(jsonPath("$.isLiked").value(false))
+			.andExpect(jsonPath("$.likeCount").value(0))
+		    .andExpect(jsonPath("$.createdAt").exists())
+			.andExpect(jsonPath("$.updatedAt").exists())
+			.andExpect(jsonPath("$.deletedAt").doesNotExist());
 	}
 
 	@Test

--- a/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
@@ -1,0 +1,98 @@
+package org.juniortown.backend.controller;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
+import org.juniortown.backend.post.repository.PostRepository;
+import org.juniortown.backend.user.dto.LoginDTO;
+import org.juniortown.backend.user.entity.User;
+import org.juniortown.backend.user.jwt.JWTUtil;
+import org.juniortown.backend.user.repository.UserRepository;
+import org.juniortown.backend.user.request.SignUpDTO;
+import org.juniortown.backend.user.service.AuthService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ActiveProfiles("test")
+@Transactional
+public class PostRedisReadController {
+	@Autowired
+	private MockMvc mockMvc;
+	private PostRepository postRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private AuthService authService;
+	@Autowired
+	private JWTUtil jwtUtil;
+
+	@BeforeEach
+	void clean() {
+		postRepository.deleteAll();
+	}
+
+	private static String jwt;
+	private User testUser;
+
+	@BeforeAll
+	public void init() throws Exception {
+		UUID uuid = UUID.randomUUID();
+		String email = uuid + "@naver.com";
+		SignUpDTO signUpDTO = SignUpDTO.builder()
+			.email(email)
+			.password("1234")
+			.username("테스터")
+			.build();
+
+		LoginDTO loginDTO = LoginDTO.builder()
+			.email(signUpDTO.getEmail())
+			.password(signUpDTO.getPassword())
+			.build();
+		authService.signUp(signUpDTO);
+		testUser = userRepository.findByEmail(email).get();
+
+		// 로그인 후 JWT 토큰을 발급받는다.
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(loginDTO))
+			)
+			.andExpect(status().isOk())
+			.andDo(result -> {
+				jwt = result.getResponse().getHeader("Authorization");
+			});
+	}
+
+	@Test
+	@DisplayName("게시글 조회수 증가 성공 - 중복키 존재 x")
+	void test1(){
+		// 1.게시글 상세 조회할 때 조회수도 이제 반환해줘야 함
+		// 2.조회수는 DB에 있는 값 + Redis에 있는 값이다.
+		// 3.상세 조회 로직을 통해 redis에 있는 증분값이 증가한다.
+		// 3-1. redis의 증분값이 여러 테스트에서 독립적으로 유지될지 모르겠네
+		// 3-2?. testContainer를 쓰면 테스트마다 다른 레디스 컨테이너를 사용하나?
+		// 4.먼저 redis 증분값을 증가시키고 조회수 값을 가져와야 한다.
+	}
+
+}

--- a/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
@@ -45,6 +45,8 @@ import org.testcontainers.utility.DockerImageName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redis.testcontainers.RedisContainer;
 
+import jakarta.servlet.http.Cookie;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 //@TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
@@ -126,12 +128,6 @@ public class PostRedisReadControllerTest {
 			});
 	}
 
-	// @AfterEach
-	// void clean() {
-	// 	userRepository.deleteAll();
-	// 	postRepository.deleteAll();
-	// }
-
 	@Test
 	@DisplayName("게시글 조회수 증가 성공(회원) - 중복키 존재 x")
 	void read_count_increase_with_user() throws Exception {
@@ -158,12 +154,13 @@ public class PostRedisReadControllerTest {
 
 
 	@Test
-	@DisplayName("게시글 조회수 증가 성공(회원) - 중복키 존재 x")
+	@DisplayName("게시글 조회수 증가 성공(비회원) - 중복키 존재 x")
 	void read_count_increase_with_non_user() throws Exception {
 		Long postId = testPost.getId();
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/details/{postId}", postId)
 				.contentType(APPLICATION_JSON)
+				.cookie(new Cookie("guestId", "testUUId"))
 			)
 			.andExpect(status().isOk())
 			.andDo(print())
@@ -205,6 +202,7 @@ public class PostRedisReadControllerTest {
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/details/{postId}", postId)
 			.contentType(APPLICATION_JSON)
+
 		).andReturn();
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/details/{postId}", postId)
@@ -224,6 +222,7 @@ public class PostRedisReadControllerTest {
 		// 비회원 조회
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/details/{postId}", postId)
 			.contentType(APPLICATION_JSON)
+			.cookie(new Cookie("guestId", "testUUId"))
 		).andReturn();
 
 		// 회원 조회

--- a/backend/src/test/java/org/juniortown/backend/like/controller/LikeControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/like/controller/LikeControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.UUID;
 
 import org.juniortown.backend.config.RedisTestConfig;
+import org.juniortown.backend.config.SyncConfig;
 import org.juniortown.backend.like.entity.Like;
 import org.juniortown.backend.like.exception.LikeFailureException;
 import org.juniortown.backend.like.repository.LikeRepository;
@@ -36,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import(RedisTestConfig.class)
+@Import({RedisTestConfig.class, SyncConfig.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @Transactional
 class LikeControllerTest {

--- a/backend/src/test/java/org/juniortown/backend/like/controller/LikeControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/like/controller/LikeControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.UUID;
 
+import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.like.entity.Like;
 import org.juniortown.backend.like.exception.LikeFailureException;
 import org.juniortown.backend.like.repository.LikeRepository;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -34,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Import(RedisTestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @Transactional
 class LikeControllerTest {

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -7,7 +7,9 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 
+import org.juniortown.backend.like.repository.LikeRepository;
 import org.juniortown.backend.post.dto.request.PostCreateRequest;
+import org.juniortown.backend.post.dto.response.PostDetailResponse;
 import org.juniortown.backend.post.dto.response.PostResponse;
 import org.juniortown.backend.post.dto.response.PostWithLikeCountProjection;
 import org.juniortown.backend.post.entity.Post;
@@ -43,6 +45,8 @@ class PostServiceTest {
 	private PostRepository postRepository;
 	@Mock
 	private UserRepository userRepository;
+	@Mock
+	private LikeRepository likeRepository;
 	@Mock
 	private Clock clock;
 
@@ -279,7 +283,7 @@ class PostServiceTest {
 		when(user.getName()).thenReturn(name);
 		when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
 
-		PostResponse result = postService.getPost(postId);
+		PostDetailResponse result = postService.getPost(postId);
 
 		// then
 		assertThat(result.getContent()).isEqualTo(content);

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -48,6 +48,8 @@ class PostServiceTest {
 	@Mock
 	private LikeRepository likeRepository;
 	@Mock
+	private ViewCountService viewCountService;
+	@Mock
 	private Clock clock;
 
 	@Mock
@@ -283,7 +285,7 @@ class PostServiceTest {
 		when(user.getName()).thenReturn(name);
 		when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
 
-		PostDetailResponse result = postService.getPost(postId);
+		PostDetailResponse result = postService.getPost(postId, String.valueOf(userId));
 
 		// then
 		assertThat(result.getContent()).isEqualTo(content);
@@ -297,12 +299,13 @@ class PostServiceTest {
 	void getPost_not_return_deleted_page() {
 		// given
 		Long postId = 999L;
+		String userId = "1";
 
 		// when
 		when(postRepository.findById(anyLong())).thenReturn(Optional.empty());
 
 		// then
-		assertThatThrownBy(() -> postService.getPost(postId))
+		assertThatThrownBy(() -> postService.getPost(postId, userId))
 			.isInstanceOf(PostNotFoundException.class)
 			.hasMessage("해당 게시글을 찾을 수 없습니다.");
 	}

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -252,6 +252,7 @@ class PostServiceTest {
 		Page<PostWithLikeCountProjection> emptyPage = Page.empty(pageable);
 		when(user.getId()).thenReturn(1L);
 		when(postRepository.findAllWithLikeCount(user.getId(),pageable)).thenReturn(emptyPage);
+		when(redisTemplate.opsForValue()).thenReturn(readCountValueOperations);
 
 		// when
 		Page<PostResponse> result = postService.getPosts(user.getId(), page);

--- a/backend/src/test/java/org/juniortown/backend/post/service/ViewCountServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/ViewCountServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.concurrent.TimeUnit;
 
+import org.juniortown.backend.config.RedisTestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import static org.mockito.Mockito.never;
@@ -41,7 +43,7 @@ class ViewCountServiceTest {
 		String userId = "1";
 		String postId = "1";
 		String dupKey = "postDup:key:" + postId + ":" + userId;
-		String readCountKey = "post:viewCount:" + postId + ":" + userId;
+		String readCountKey = "post:viewCount:" + postId;
 
 		when(keyCheckRedisTemplate.opsForValue()).thenReturn(keyCheckValueOperations);
 		when(readCountRedisTemplate.opsForValue()).thenReturn(readCountValueOperations);
@@ -61,15 +63,17 @@ class ViewCountServiceTest {
 		String userId = "1";
 		String postId = "1";
 		String dupKey = "postDup:key:" + postId + ":" + userId;
-		String readCountKey = "post:viewCount:" + postId + ":" + userId;
+		String readCountKey = "post:viewCount:" + postId;
 
 		when(keyCheckRedisTemplate.opsForValue()).thenReturn(keyCheckValueOperations);
+		when(readCountRedisTemplate.opsForValue()).thenReturn(readCountValueOperations);
 		when(keyCheckValueOperations.get(dupKey)).thenReturn(true);
+		when(readCountValueOperations.get(readCountKey)).thenReturn(1L);
 		// when
 		viewCountService.readCountUp(userId, postId);
 
 		// then
 		verify(keyCheckValueOperations, never()).set(eq(dupKey), eq(true), eq(10L), eq(TimeUnit.MINUTES));
-
+		verify(readCountRedisTemplate.opsForValue()).get(readCountKey);
 	}
 }

--- a/backend/src/test/java/org/juniortown/backend/post/service/ViewCountServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/ViewCountServiceTest.java
@@ -1,0 +1,75 @@
+package org.juniortown.backend.post.service;
+
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ViewCountServiceTest {
+	@Mock
+	private ViewCountService viewCountService;
+	@Mock
+	private RedisTemplate<String, Boolean> keyCheckRedisTemplate;
+	@Mock
+	private ValueOperations<String, Boolean> keyCheckValueOperations;
+	@Mock
+	private RedisTemplate<String, Long> readCountRedisTemplate;
+	@Mock
+	private ValueOperations<String, Long> readCountValueOperations;
+
+	@BeforeEach
+	public void setUp() {
+		viewCountService = new ViewCountService(keyCheckRedisTemplate, readCountRedisTemplate);
+	}
+
+	@Test
+	@DisplayName("조회수 증가 성공 - 중복키 존재 x")
+	void incrementViewCount_success() {
+		// given
+		String userId = "1";
+		String postId = "1";
+		String dupKey = "postDup:key:" + postId + ":" + userId;
+		String readCountKey = "post:viewCount:" + postId + ":" + userId;
+
+		when(keyCheckRedisTemplate.opsForValue()).thenReturn(keyCheckValueOperations);
+		when(readCountRedisTemplate.opsForValue()).thenReturn(readCountValueOperations);
+		when(keyCheckValueOperations.get(dupKey)).thenReturn(null);
+		// when
+		viewCountService.readCountUp(userId, postId);
+
+		// then
+		verify(keyCheckValueOperations).set(eq(dupKey), eq(true), eq(10L), eq(TimeUnit.MINUTES));
+		verify(readCountRedisTemplate.opsForValue()).increment(readCountKey);
+	}
+
+	@Test
+	@DisplayName("조회수 증가 실패 - 중복키 존재 o")
+	void incrementViewCount_fail() {
+		// given
+		String userId = "1";
+		String postId = "1";
+		String dupKey = "postDup:key:" + postId + ":" + userId;
+		String readCountKey = "post:viewCount:" + postId + ":" + userId;
+
+		when(keyCheckRedisTemplate.opsForValue()).thenReturn(keyCheckValueOperations);
+		when(keyCheckValueOperations.get(dupKey)).thenReturn(true);
+		// when
+		viewCountService.readCountUp(userId, postId);
+
+		// then
+		verify(keyCheckValueOperations, never()).set(eq(dupKey), eq(true), eq(10L), eq(TimeUnit.MINUTES));
+
+	}
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,3 +1,4 @@
+
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/myDB
@@ -9,6 +10,8 @@ spring:
       pageable:
         one-indexed-parameters: true
         default-page-size: 5
+
+
   sql:
     init:
       mode: never
@@ -24,3 +27,4 @@ spring:
 
   jwt:
     secret: abcdeferasddatestkeysadfadsfadfdvdsf
+

--- a/frontend/src/pages/posts/PostDetailPage.jsx
+++ b/frontend/src/pages/posts/PostDetailPage.jsx
@@ -111,6 +111,9 @@ const PostDetailPage = () => {
                     minute: "2-digit",
                   })}
                 </small>
+                <small className="text-muted ms-2">
+                  👁️ {post.readCount?.toLocaleString()}회
+                </small>
               </Card.Header>
               <Card.Body>
                 <Card.Text style={{ whiteSpace: "pre-wrap", lineHeight: 1.6 }}>

--- a/frontend/src/pages/posts/PostListPage.jsx
+++ b/frontend/src/pages/posts/PostListPage.jsx
@@ -144,6 +144,7 @@ const PostListPage = () => {
                   <th>작성일</th>
                   <th>작성자</th>
                   <th>좋아요</th>
+                  <th>조회수</th>
                   <th>액션</th>
                 </tr>
               </thead>
@@ -172,6 +173,7 @@ const PostListPage = () => {
                       </button>
                       <span style={{ fontWeight: 'bold', marginLeft: 4 }}>{post.likeCount}</span>
                     </td>
+                    <td>{post.readCount}</td>
                     <td>
                       <Button size="sm" variant="outline-primary" onClick={() => navigate(`/posts/${post.id}`)}>
                         상세 보기


### PR DESCRIPTION
1.레디스 연동
2.게시글 상세 조회 시 레디스의 키값 증가, 단시간 내의 중복 조회 막는 로직 구현
3.게시글 조회 시 조회수도 내려주기(DB값 + Redis 증분)
4.주기적으로 Redis 증분값을 DB에 동기화
closed #11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글 조회수 집계 기능이 Redis 기반으로 구현되어, 조회수 증가 및 동기화가 효율적으로 처리됩니다.
  * 비회원 방문자도 고유 쿠키를 통해 조회수가 집계됩니다.
  * 게시글 상세 조회 API가 조회수, 좋아요 여부, 좋아요 개수 등 상세 정보를 함께 반환하도록 개선되었습니다.
  * 스케줄러를 통한 조회수 동기화 기능이 추가되어 Redis에 저장된 조회수를 주기적으로 DB에 반영합니다.
  * 비회원 식별을 위한 쿠키 발급 기능이 도입되어 비회원 조회수 집계가 가능해졌습니다.

* **버그 수정**
  * 게시글 목록 및 상세 조회 시 좋아요 개수와 내가 좋아요를 눌렀는지 여부가 정확히 표시됩니다.

* **테스트**
  * Redis 연동 및 조회수 관련 기능에 대한 통합 테스트와 단위 테스트가 추가되었습니다.
  * 조회수 중복 증가 방지, 비회원/회원 조회수 집계, 조회수 동기화 스케줄러 동작 검증 테스트가 포함되었습니다.

* **환경설정**
  * Redis 및 Redisson 클라이언트 의존성이 추가되고, 테스트용 Redis 환경 및 Mock 설정이 도입되었습니다.
  * Redis 연결 설정이 기본 구성에 포함되었습니다.

* **UI 개선**
  * 게시글 목록과 상세 페이지에 조회수 컬럼 및 아이콘(👁️)이 추가되어 사용자가 쉽게 조회수를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->