### PR TITLE
Feat#13 댓글/대댓글기능

### DIFF
--- a/backend/src/main/java/org/juniortown/backend/BackendApplication.java
+++ b/backend/src/main/java/org/juniortown/backend/BackendApplication.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @EnableScheduling
 public class BackendApplication {
 

--- a/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package org.juniortown.backend.comment.controller;
 
 import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
+import org.juniortown.backend.comment.dto.request.CommentUpdateRequest;
 import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
 import org.juniortown.backend.comment.service.CommentService;
 import org.juniortown.backend.user.dto.CustomUserDetails;
@@ -8,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,6 +39,13 @@ public class CommentController {
 		@PathVariable Long commentId) {
 		Long userId = customUserDetails.getUserId();
 		commentService.deleteComment(userId, commentId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+	@PatchMapping("/comments/{commentId}")
+	public ResponseEntity<?> CommentUpdateRequest(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable Long commentId, @Valid @RequestBody CommentUpdateRequest commentUpdateRequest) {
+		Long userId = customUserDetails.getUserId();
+		commentService.updateComment(userId, commentId, commentUpdateRequest);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
@@ -35,14 +35,14 @@ public class CommentController {
 	}
 
 	@DeleteMapping("/comments/{commentId}")
-	public ResponseEntity<?> CommentDeleteRequest(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+	public ResponseEntity<?> commentDeleteRequest(@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@PathVariable Long commentId) {
 		Long userId = customUserDetails.getUserId();
 		commentService.deleteComment(userId, commentId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 	@PatchMapping("/comments/{commentId}")
-	public ResponseEntity<?> CommentUpdateRequest(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+	public ResponseEntity<?> commentUpdateRequest(@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@PathVariable Long commentId, @Valid @RequestBody CommentUpdateRequest commentUpdateRequest) {
 		Long userId = customUserDetails.getUserId();
 		commentService.updateComment(userId, commentId, commentUpdateRequest);

--- a/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
@@ -7,6 +7,8 @@ import org.juniortown.backend.user.dto.CustomUserDetails;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +30,13 @@ public class CommentController {
 		CommentCreateResponse response = commentService.createComment(userId, commentCreateRequest);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@DeleteMapping("/comments/{commentId}")
+	public ResponseEntity<?> CommentDeleteRequest(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable Long commentId) {
+		Long userId = customUserDetails.getUserId();
+		commentService.deleteComment(userId, commentId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
@@ -1,0 +1,30 @@
+package org.juniortown.backend.comment.controller;
+
+import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
+import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
+import org.juniortown.backend.comment.service.CommentService;
+import org.juniortown.backend.user.dto.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CommentController {
+	private final CommentService commentService;
+	@PostMapping("/comment")
+	public ResponseEntity<CommentCreateResponse> createComment(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@Valid @RequestBody CommentCreateRequest commentCreateRequest) {
+		Long userId = customUserDetails.getUserId();
+
+		CommentCreateResponse response = commentService.createComment(userId, commentCreateRequest);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
 import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
 import org.juniortown.backend.comment.service.CommentService;
 import org.juniortown.backend.user.dto.CustomUserDetails;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,12 +20,13 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api")
 public class CommentController {
 	private final CommentService commentService;
-	@PostMapping("/comment")
+	@PostMapping("/comments")
 	public ResponseEntity<CommentCreateResponse> createComment(@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@Valid @RequestBody CommentCreateRequest commentCreateRequest) {
 		Long userId = customUserDetails.getUserId();
 
 		CommentCreateResponse response = commentService.createComment(userId, commentCreateRequest);
-		return ResponseEntity.ok(response);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/request/CommentCreateRequest.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,16 @@
+package org.juniortown.backend.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommentCreateRequest {
+	@NotNull(message = "게시글 ID를 입력해주세요.")
+	private final Long postId;
+	private final Long parentId;
+	@NotBlank(message = "댓글 내용을 입력해주세요.")
+	private final String content;
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/request/CommentCreateRequest.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/request/CommentCreateRequest.java
@@ -2,15 +2,22 @@ package org.juniortown.backend.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class CommentCreateRequest {
 	@NotNull(message = "게시글 ID를 입력해주세요.")
 	private final Long postId;
 	private final Long parentId;
 	@NotBlank(message = "댓글 내용을 입력해주세요.")
 	private final String content;
+
+	@Builder
+	public CommentCreateRequest(Long postId, Long parentId, String content) {
+		this.postId = postId;
+		this.parentId = parentId;
+		this.content = content;
+	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,15 @@
+package org.juniortown.backend.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentUpdateRequest {
+	@NotBlank(message = "댓글 내용을 입력해주세요.")
+	private final String content;
+	@Builder
+	public CommentUpdateRequest(String content) {
+		this.content = content;
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentCreateResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,40 @@
+package org.juniortown.backend.comment.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.juniortown.backend.comment.entity.Comment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentCreateResponse {
+	private final Long commentId;
+	private final String content;
+	private final Long postId;
+	private final Long parentId;
+	private final Long userId;
+	private final String username;
+	private final LocalDateTime createdAt;
+	@Builder
+	public CommentCreateResponse(Long commentId, String content, Long postId, Long parentId, Long userId, String username, LocalDateTime createdAt) {
+		this.commentId = commentId;
+		this.content = content;
+		this.postId = postId;
+		this.parentId = parentId;
+		this.userId = userId;
+		this.username = username;
+		this.createdAt = createdAt;
+	}
+	public static CommentCreateResponse from(Comment comment) {
+		return CommentCreateResponse.builder()
+			.commentId(comment.getId())
+			.content(comment.getContent())
+			.postId(comment.getPost().getId())
+			.parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+			.userId(comment.getUser().getId())
+			.username(comment.getUsername())
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentCreateResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentCreateResponse.java
@@ -33,7 +33,7 @@ public class CommentCreateResponse {
 			.postId(comment.getPost().getId())
 			.parentId(comment.getParent() != null ? comment.getParent().getId() : null)
 			.userId(comment.getUser().getId())
-			.username(comment.getUsername())
+			.username(comment.getUser().getName())
 			.createdAt(comment.getCreatedAt())
 			.build();
 	}

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentsInPost.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentsInPost.java
@@ -1,0 +1,54 @@
+package org.juniortown.backend.comment.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.juniortown.backend.comment.entity.Comment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentsInPost {
+	private final Long commentId;
+	private final Long postId;
+	private final Long parentId;
+	private final Long userId;
+	private final String content;
+	private final String username;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+	private final LocalDateTime deletedAt;
+	private List<CommentsInPost> children = new ArrayList<>();
+	@Builder
+	public CommentsInPost(Long commentId, Long postId, Long parentId, Long userId, String content, String username, LocalDateTime createdAt,
+		LocalDateTime updatedAt, LocalDateTime deletedAt) {
+		this.commentId = commentId;
+		this.postId = postId;
+		this.parentId = parentId;
+		this.userId = userId;
+		this.content = content;
+		this.username = username;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.deletedAt = deletedAt;
+	}
+
+	public static CommentsInPost from(Comment comment) {
+		return CommentsInPost.builder()
+			.commentId(comment.getId())
+			.postId(comment.getPost().getId())
+			// 근데 이게 꼭 필요한가? userId 쓰는 경우가 생각이 안나
+			.userId(comment.getUser().getId())
+			.parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+			.content(comment.getContent())
+			// 이게 원래는 user 테이블을 조회해야하는데 comment에 username이 있으니까
+			// 조회를 안해도 되는 사기 스킬
+			.username(comment.getUsername())
+			.createdAt(comment.getCreatedAt())
+			.updatedAt(comment.getUpdatedAt())
+			.deletedAt(comment.getDeletedAt())
+			.build();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentsInPost.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/dto/response/CommentsInPost.java
@@ -20,7 +20,7 @@ public class CommentsInPost {
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final LocalDateTime deletedAt;
-	private List<CommentsInPost> children = new ArrayList<>();
+	private final List<CommentsInPost> children = new ArrayList<>();
 	@Builder
 	public CommentsInPost(Long commentId, Long postId, Long parentId, Long userId, String content, String username, LocalDateTime createdAt,
 		LocalDateTime updatedAt, LocalDateTime deletedAt) {

--- a/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.juniortown.backend.comment.dto.request.CommentUpdateRequest;
 import org.juniortown.backend.comment.exception.AlreadyDeletedCommentException;
 import org.juniortown.backend.entity.BaseTimeEntity;
 import org.juniortown.backend.post.entity.Post;
@@ -73,4 +74,11 @@ public class Comment extends BaseTimeEntity {
 		this.deletedAt = LocalDateTime.now(clock);
 	}
 
+	public void update(CommentUpdateRequest commentUpdateRequest, Clock clock) {
+		if (this.deletedAt != null) {
+			throw new AlreadyDeletedCommentException();
+		}
+		this.content = commentUpdateRequest.getContent();
+		this.updatedAt = LocalDateTime.now(clock);
+	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
@@ -79,6 +79,6 @@ public class Comment extends BaseTimeEntity {
 			throw new AlreadyDeletedCommentException();
 		}
 		this.content = commentUpdateRequest.getContent();
-		this.updatedAt = LocalDateTime.now(clock);
+		//this.updatedAt = LocalDateTime.now(clock);
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.juniortown.backend.comment.exception.AlreadyDeletedCommentException;
 import org.juniortown.backend.entity.BaseTimeEntity;
 import org.juniortown.backend.post.entity.Post;
 import org.juniortown.backend.user.entity.User;
@@ -66,6 +67,9 @@ public class Comment extends BaseTimeEntity {
 	}
 
 	public void softDelete(Clock clock) {
+		if(this.deletedAt != null) {
+			throw new AlreadyDeletedCommentException();
+		}
 		this.deletedAt = LocalDateTime.now(clock);
 	}
 

--- a/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
@@ -1,0 +1,72 @@
+package org.juniortown.backend.comment.entity;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.juniortown.backend.entity.BaseTimeEntity;
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Comment extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "parent_id")
+	private Comment parent;
+
+	@Lob
+	private String content;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "username", nullable = false)
+	private String username;
+
+	@ManyToOne
+	@JoinColumn(name = "post_id", nullable = false)
+	private Post post;
+
+	// 임시로 작성
+	@OneToMany(mappedBy = "parent")
+	private List<Comment> replies = new ArrayList<>();
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+	@Builder
+	public Comment(Comment parent, String content, User user,String username, Post post) {
+		this.parent = parent;
+		this.content = content;
+		this.user = user;
+		this.username = username;
+		this.post = post;
+	}
+
+	public void softDelete(Clock clock) {
+		this.deletedAt = LocalDateTime.now(clock);
+	}
+
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/entity/Comment.java
@@ -79,6 +79,5 @@ public class Comment extends BaseTimeEntity {
 			throw new AlreadyDeletedCommentException();
 		}
 		this.content = commentUpdateRequest.getContent();
-		//this.updatedAt = LocalDateTime.now(clock);
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/AlreadyDeletedCommentException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/AlreadyDeletedCommentException.java
@@ -1,0 +1,17 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyDeletedCommentException extends CustomException {
+	public static final String MESSAGE = "이미 삭제된 댓글입니다.";
+
+	public AlreadyDeletedCommentException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.NOT_FOUND.value();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/CircularReferenceException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/CircularReferenceException.java
@@ -1,0 +1,16 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class CircularReferenceException extends CustomException {
+	public static final String MESSAGE = "댓글 순환 참조 발생!";
+	public CircularReferenceException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.BAD_REQUEST.value();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/CommentNotFoundException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/CommentNotFoundException.java
@@ -3,7 +3,7 @@ package org.juniortown.backend.comment.exception;
 import org.juniortown.backend.exception.CustomException;
 
 public class CommentNotFoundException extends CustomException {
-	private static final String MESSAGE = "해당 댓글을 찾을 수 없습니다.";
+	public static final String MESSAGE = "해당 댓글을 찾을 수 없습니다.";
 
 	public CommentNotFoundException() {
 		super(MESSAGE);

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/CommentNotFoundException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,16 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+
+public class CommentNotFoundException extends CustomException {
+	private static final String MESSAGE = "해당 댓글을 찾을 수 없습니다.";
+
+	public CommentNotFoundException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 404;
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/DepthLimitTwoException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/DepthLimitTwoException.java
@@ -1,0 +1,17 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class DepthLimitTwoException extends CustomException {
+	public static final String MESSAGE = "댓글은 최대 2단계까지만 가능합니다.";
+
+	public DepthLimitTwoException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.BAD_REQUEST.value();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/NoRightForCommentDeleteException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/NoRightForCommentDeleteException.java
@@ -1,0 +1,17 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoRightForCommentDeleteException extends CustomException {
+public static final String MESSAGE = "해당 댓글을 삭제할 권한이 없습니다.";
+
+	public NoRightForCommentDeleteException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.FORBIDDEN.value();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/NoRightForCommentUpdateException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/NoRightForCommentUpdateException.java
@@ -1,0 +1,17 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoRightForCommentUpdateException extends CustomException {
+public static final String MESSAGE = "해당 댓글을 수정할 권한이 없습니다.";
+
+	public NoRightForCommentUpdateException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.FORBIDDEN.value();
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/ParentPostMismatchException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/ParentPostMismatchException.java
@@ -3,7 +3,7 @@ package org.juniortown.backend.comment.exception;
 import org.juniortown.backend.exception.CustomException;
 
 public class ParentPostMismatchException extends CustomException {
-	private static final String MESSAGE = "부모 댓글의 게시글과 대댓글이 속한 게시글이 일치하지 않습니다.";
+	public static final String MESSAGE = "부모 댓글의 게시글과 대댓글이 속한 게시글이 일치하지 않습니다.";
 
 	public ParentPostMismatchException() {
 		super(MESSAGE);

--- a/backend/src/main/java/org/juniortown/backend/comment/exception/ParentPostMismatchException.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/exception/ParentPostMismatchException.java
@@ -1,0 +1,16 @@
+package org.juniortown.backend.comment.exception;
+
+import org.juniortown.backend.exception.CustomException;
+
+public class ParentPostMismatchException extends CustomException {
+	private static final String MESSAGE = "부모 댓글의 게시글과 대댓글이 속한 게시글이 일치하지 않습니다.";
+
+	public ParentPostMismatchException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 400; // Bad Request
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/repository/CommentRepository.java
@@ -6,5 +6,5 @@ import org.juniortown.backend.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-	List<Comment> findByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long postId);
+	List<Comment> findByPostIdOrderByCreatedAtAsc(Long postId);
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.juniortown.backend.comment.repository;
+
+import org.juniortown.backend.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package org.juniortown.backend.comment.repository;
 
+import java.util.List;
+
 import org.juniortown.backend.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+	List<Comment> findByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long postId);
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
@@ -1,9 +1,12 @@
 package org.juniortown.backend.comment.service;
 
+import java.time.Clock;
+
 import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
 import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
 import org.juniortown.backend.comment.entity.Comment;
 import org.juniortown.backend.comment.exception.CommentNotFoundException;
+import org.juniortown.backend.comment.exception.NoRightForCommentDeleteException;
 import org.juniortown.backend.comment.exception.ParentPostMismatchException;
 import org.juniortown.backend.comment.repository.CommentRepository;
 import org.juniortown.backend.post.entity.Post;
@@ -16,13 +19,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentService {
 	private final CommentRepository commentRepository;
 	private final UserRepository userRepository;
 	private final PostRepository postRepository;
+	private final Clock clock;
 	@Transactional
 	public CommentCreateResponse createComment(Long userId, CommentCreateRequest commentCreateRequest) {
 		String content = commentCreateRequest.getContent();
@@ -30,16 +36,26 @@ public class CommentService {
 		Long parentId = commentCreateRequest.getParentId();
 
 		 User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserNotFoundException());
+			.orElseThrow(() -> {
+				log.info("User not found with id: {}", userId);
+				return new UserNotFoundException();
+			});
 		 Post post = postRepository.findById(postId)
-			 .orElseThrow(() -> new PostNotFoundException());
+			 .orElseThrow(() -> {
+				log.info("Post not found with id: {}", postId);
+				 return new PostNotFoundException();
+			 });
 
 		// 최상위 댓글인 경우
 		Comment parentComment = null;
 		if (parentId != null) {
 			parentComment = commentRepository.findById(parentId)
-				.orElseThrow(() -> new CommentNotFoundException());
+				.orElseThrow(() -> {
+					log.info("Parent comment not found with id: {}", parentId);
+					return new CommentNotFoundException();
+				});
 			if(!parentComment.getPost().getId().equals(postId)) {
+				log.info("comment의 postId {}가 post ID {}와 다름.", parentComment.getPost().getId(), postId);
 				throw new ParentPostMismatchException();
 			}
 		}
@@ -54,5 +70,25 @@ public class CommentService {
 
 		Comment saveComment = commentRepository.save(comment);
 		return CommentCreateResponse.from(saveComment);
+	}
+
+	public void deleteComment(Long userId, Long commentId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> {
+				log.info("User not found with id: {}", userId);
+				return new UserNotFoundException();
+			});
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> {
+				log.info("Comment not found with id: {}", commentId);
+				return new CommentNotFoundException();
+			});
+
+		if (!comment.getUser().getId().equals(user.getId())) {
+			log.info("User {} does not have permission to delete comment {}", userId, commentId);
+			throw new NoRightForCommentDeleteException();
+		}
+
+		comment.softDelete(clock);
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
@@ -6,7 +6,9 @@ import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
 import org.juniortown.backend.comment.dto.request.CommentUpdateRequest;
 import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
 import org.juniortown.backend.comment.entity.Comment;
+import org.juniortown.backend.comment.exception.AlreadyDeletedCommentException;
 import org.juniortown.backend.comment.exception.CommentNotFoundException;
+import org.juniortown.backend.comment.exception.DepthLimitTwoException;
 import org.juniortown.backend.comment.exception.NoRightForCommentDeleteException;
 import org.juniortown.backend.comment.exception.ParentPostMismatchException;
 import org.juniortown.backend.comment.repository.CommentRepository;
@@ -56,6 +58,14 @@ public class CommentService {
 					log.info("Parent comment not found with id: {}", parentId);
 					return new CommentNotFoundException();
 				});
+			if (parentComment.getDeletedAt() != null) {
+				log.info("Parent comment with id {} is already deleted.", parentId);
+				throw new AlreadyDeletedCommentException();
+			}
+			if(parentComment.getParent() != null) {
+				log.info("depth는 2로 제한됩니다. 현재 parentComment의 parent가 존재합니다.");
+				throw new DepthLimitTwoException();
+			}
 			if(!parentComment.getPost().getId().equals(postId)) {
 				log.info("comment의 postId {}가 post ID {}와 다름.", parentComment.getPost().getId(), postId);
 				throw new ParentPostMismatchException();

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import org.juniortown.backend.comment.exception.AlreadyDeletedCommentException;
 import org.juniortown.backend.comment.exception.CommentNotFoundException;
 import org.juniortown.backend.comment.exception.DepthLimitTwoException;
 import org.juniortown.backend.comment.exception.NoRightForCommentDeleteException;
+import org.juniortown.backend.comment.exception.NoRightForCommentUpdateException;
 import org.juniortown.backend.comment.exception.ParentPostMismatchException;
 import org.juniortown.backend.comment.repository.CommentRepository;
 import org.juniortown.backend.post.entity.Post;
@@ -118,7 +119,7 @@ public class CommentService {
 
 		if (!comment.getUser().getId().equals(user.getId())) {
 			log.info("User {} does not have permission to update comment {}", userId, commentId);
-			throw new NoRightForCommentDeleteException();
+			throw new NoRightForCommentUpdateException();
 		}
 		comment.update(commentUpdateRequest, clock);
 	}

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
@@ -1,0 +1,58 @@
+package org.juniortown.backend.comment.service;
+
+import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
+import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
+import org.juniortown.backend.comment.entity.Comment;
+import org.juniortown.backend.comment.exception.CommentNotFoundException;
+import org.juniortown.backend.comment.exception.ParentPostMismatchException;
+import org.juniortown.backend.comment.repository.CommentRepository;
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.post.exception.PostNotFoundException;
+import org.juniortown.backend.post.repository.PostRepository;
+import org.juniortown.backend.user.entity.User;
+import org.juniortown.backend.user.exception.UserNotFoundException;
+import org.juniortown.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+	private final CommentRepository commentRepository;
+	private final UserRepository userRepository;
+	private final PostRepository postRepository;
+	@Transactional
+	public CommentCreateResponse createComment(Long userId, CommentCreateRequest commentCreateRequest) {
+		String content = commentCreateRequest.getContent();
+		Long postId = commentCreateRequest.getPostId();
+		Long parentId = commentCreateRequest.getParentId();
+
+		 User user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserNotFoundException());
+		 Post post = postRepository.findById(postId)
+			 .orElseThrow(() -> new PostNotFoundException());
+
+		// 최상위 댓글인 경우
+		Comment parentComment = null;
+		if (parentId != null) {
+			parentComment = commentRepository.findById(parentId)
+				.orElseThrow(() -> new CommentNotFoundException());
+			if(!parentComment.getPost().getId().equals(postId)) {
+				throw new ParentPostMismatchException();
+			}
+		}
+
+		Comment comment = Comment.builder()
+			.content(content)
+			.user(user)
+			.username(user.getName())
+			.post(post)
+			.parent(parentComment)
+			.build();
+
+		Comment saveComment = commentRepository.save(comment);
+		return CommentCreateResponse.from(saveComment);
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package org.juniortown.backend.comment.service;
 import java.time.Clock;
 
 import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
+import org.juniortown.backend.comment.dto.request.CommentUpdateRequest;
 import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
 import org.juniortown.backend.comment.entity.Comment;
 import org.juniortown.backend.comment.exception.CommentNotFoundException;
@@ -90,5 +91,24 @@ public class CommentService {
 		}
 
 		comment.softDelete(clock);
+	}
+
+	public void updateComment(Long userId, Long commentId, CommentUpdateRequest commentUpdateRequest) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> {
+				log.info("User not found with id: {}", userId);
+				return new UserNotFoundException();
+			});
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> {
+				log.info("Comment not found with id: {}", commentId);
+				return new CommentNotFoundException();
+			});
+
+		if (!comment.getUser().getId().equals(user.getId())) {
+			log.info("User {} does not have permission to update comment {}", userId, commentId);
+			throw new NoRightForCommentDeleteException();
+		}
+		comment.update(commentUpdateRequest, clock);
 	}
 }

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentService.java
@@ -25,12 +25,13 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class CommentService {
 	private final CommentRepository commentRepository;
 	private final UserRepository userRepository;
 	private final PostRepository postRepository;
 	private final Clock clock;
-	@Transactional
+
 	public CommentCreateResponse createComment(Long userId, CommentCreateRequest commentCreateRequest) {
 		String content = commentCreateRequest.getContent();
 		Long postId = commentCreateRequest.getPostId();

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentTreeBuilder.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentTreeBuilder.java
@@ -1,0 +1,30 @@
+package org.juniortown.backend.comment.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.juniortown.backend.comment.dto.response.CommentsInPost;
+import org.juniortown.backend.comment.entity.Comment;
+
+public class CommentTreeBuilder {
+	public static List<CommentsInPost> build(List<Comment> comments) {
+		if(comments.isEmpty()) return List.of();
+		Map<Long, CommentsInPost> map = new HashMap<>();
+		List<CommentsInPost> roots = new ArrayList<>();
+		for (Comment c : comments) {
+			CommentsInPost comment = CommentsInPost.from(c);
+			map.put(comment.getCommentId(), comment);
+			if (c.getParent() == null) {
+				roots.add(comment);
+			} else{
+				CommentsInPost parent = map.get(c.getParent().getId());
+				if(parent != null) {
+					parent.getChildren().add(comment);
+				}
+			}
+		}
+		return roots;
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/comment/service/CommentTreeBuilder.java
+++ b/backend/src/main/java/org/juniortown/backend/comment/service/CommentTreeBuilder.java
@@ -11,16 +11,21 @@ import org.juniortown.backend.comment.entity.Comment;
 public class CommentTreeBuilder {
 	public static List<CommentsInPost> build(List<Comment> comments) {
 		if(comments.isEmpty()) return List.of();
-		Map<Long, CommentsInPost> map = new HashMap<>();
 		List<CommentsInPost> roots = new ArrayList<>();
+		Map<Long, CommentsInPost> map = new HashMap<>();
+		// 1. 모든 댓글을 Map에 넣는다
 		for (Comment c : comments) {
 			CommentsInPost comment = CommentsInPost.from(c);
 			map.put(comment.getCommentId(), comment);
+		}
+		// 2. 부모-자식 관계 설정
+		for (Comment c : comments) {
+			CommentsInPost comment = map.get(c.getId());
 			if (c.getParent() == null) {
 				roots.add(comment);
-			} else{
+			} else {
 				CommentsInPost parent = map.get(c.getParent().getId());
-				if(parent != null) {
+				if (parent != null) {
 					parent.getChildren().add(comment);
 				}
 			}

--- a/backend/src/main/java/org/juniortown/backend/config/AuditingDateTimeProvider.java
+++ b/backend/src/main/java/org/juniortown/backend/config/AuditingDateTimeProvider.java
@@ -1,0 +1,22 @@
+package org.juniortown.backend.config;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.Optional;
+
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component("auditingDateTimeProvider")
+@RequiredArgsConstructor
+public class AuditingDateTimeProvider implements DateTimeProvider {
+	private final Clock clock;
+
+	@Override
+	public Optional<TemporalAccessor> getNow() {
+		return Optional.of(LocalDateTime.now(clock));
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/config/TimeConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/TimeConfig.java
@@ -4,8 +4,10 @@ import java.time.Clock;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!test")
 public class TimeConfig {
 	@Bean
 	public Clock clock() {

--- a/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
+++ b/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
@@ -7,12 +7,14 @@ import org.juniortown.backend.user.repository.UserRepository;
 import org.juniortown.backend.user.request.SignUpDTO;
 import org.juniortown.backend.user.service.AuthService;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("default")
 public class DummyDataInit implements CommandLineRunner {
 	private final UserRepository userRepository;
 	private final PostRepository postRepository;

--- a/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
+++ b/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
@@ -28,7 +28,7 @@ public class DummyDataInit implements CommandLineRunner {
 			.username("testUser")
 			.password("1234")
 			.build();
-		// 와 반환값 살벌하네
+
 		authService.signUp(signUpDTO);
 
 		User user = userRepository.findByEmail(signUpDTO.getEmail())

--- a/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
+++ b/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Profile("default")
+@Profile("!test")
 public class DummyDataInit implements CommandLineRunner {
 	private final UserRepository userRepository;
 	private final PostRepository postRepository;

--- a/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
+++ b/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
@@ -26,7 +26,7 @@ public class DummyDataInit implements CommandLineRunner {
 		SignUpDTO signUpDTO = SignUpDTO.builder()
 			.email("test@email.com")
 			.username("testUser")
-			.password("password")
+			.password("1234")
 			.build();
 		// 와 반환값 살벌하네
 		authService.signUp(signUpDTO);

--- a/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
+++ b/backend/src/main/java/org/juniortown/backend/dummyData/DummyDataInit.java
@@ -1,0 +1,50 @@
+package org.juniortown.backend.dummyData;
+
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.post.repository.PostRepository;
+import org.juniortown.backend.user.entity.User;
+import org.juniortown.backend.user.repository.UserRepository;
+import org.juniortown.backend.user.request.SignUpDTO;
+import org.juniortown.backend.user.service.AuthService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DummyDataInit implements CommandLineRunner {
+	private final UserRepository userRepository;
+	private final PostRepository postRepository;
+	private final AuthService authService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		// 회원 가입
+		SignUpDTO signUpDTO = SignUpDTO.builder()
+			.email("test@email.com")
+			.username("testUser")
+			.password("password")
+			.build();
+		// 와 반환값 살벌하네
+		authService.signUp(signUpDTO);
+
+		User user = userRepository.findByEmail(signUpDTO.getEmail())
+			.orElseThrow(() -> new RuntimeException("User not found"));
+
+		// 게시글 생성
+		Post testPost1 = Post.builder()
+			.title("Dummy Post Title")
+			.content("This is a dummy post content.")
+			.user(user)
+			.build();
+		postRepository.save(testPost1);
+
+		Post testPost2 = Post.builder()
+			.title("Another Dummy Post Title")
+			.content("This is another dummy post content.")
+			.user(user)
+			.build();
+		postRepository.save(testPost2);
+	}
+}

--- a/backend/src/main/java/org/juniortown/backend/post/dto/request/PostCreateRequest.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/request/PostCreateRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-@Setter
+@Setter //??
 @Getter
 @ToString
 public class PostCreateRequest {
@@ -22,12 +22,6 @@ public class PostCreateRequest {
 		this.title = title;
 		this.content = content;
 	}
-
-	// public void validate() {
-	// 	if (title.contains("바보")) {
-	// 		throw new InvalidRequest("title", "제목에 바보를 포함할 수 없습니다.");
-	// 	}
-	// }
 
 	public Post toEntity(User user) {
 		return Post.builder()

--- a/backend/src/main/java/org/juniortown/backend/post/dto/response/PostDetailResponse.java
+++ b/backend/src/main/java/org/juniortown/backend/post/dto/response/PostDetailResponse.java
@@ -1,6 +1,9 @@
 package org.juniortown.backend.post.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
+import org.juniortown.backend.comment.dto.response.CommentsInPost;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -15,13 +18,14 @@ public class PostDetailResponse {
 	private final Long likeCount;
 	private final Boolean isLiked;
 	private final Long readCount;
+	private final List<CommentsInPost> comments;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final LocalDateTime deletedAt;
 
 	@Builder
 	public PostDetailResponse(Long id, String title, String content, Long userId, String userName, Long likeCount,
-			Boolean isLiked, Long readCount, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+			Boolean isLiked, Long readCount, List<CommentsInPost> comments, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
 		this.id = id;
 		this.title = title;
 		this.content = content;
@@ -30,6 +34,7 @@ public class PostDetailResponse {
 		this.likeCount = likeCount;
 		this.isLiked = isLiked;
 		this.readCount = readCount;
+		this.comments = comments;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
 		this.deletedAt = deletedAt;

--- a/backend/src/main/java/org/juniortown/backend/post/exception/PostNotFoundException.java
+++ b/backend/src/main/java/org/juniortown/backend/post/exception/PostNotFoundException.java
@@ -3,7 +3,7 @@ package org.juniortown.backend.post.exception;
 import org.juniortown.backend.exception.CustomException;
 
 public class PostNotFoundException extends CustomException {
-	private static final String MESSAGE = "해당 게시글을 찾을 수 없습니다.";
+	public static final String MESSAGE = "해당 게시글을 찾을 수 없습니다.";
 	public PostNotFoundException() {
 		super(MESSAGE);
 	}

--- a/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
@@ -5,7 +5,6 @@ import org.juniortown.backend.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -27,6 +26,4 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 			"GROUP BY p.id, p.title, p.readCount, u.name, u.id, p.createdAt, p.updatedAt, p.deletedAt"
 	)
 	Page<PostWithLikeCountProjection> findAllWithLikeCount(@Param("userId") Long userId, Pageable pageable);
-
-
 }

--- a/backend/src/main/java/org/juniortown/backend/post/service/PostService.java
+++ b/backend/src/main/java/org/juniortown/backend/post/service/PostService.java
@@ -1,10 +1,7 @@
 package org.juniortown.backend.post.service;
 
 import java.time.Clock;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -146,7 +143,7 @@ public class PostService {
 		Long redisReadCount = viewCountService.readCountUp(viewerId, postId.toString());
 
 		// 댓글 조회 로직
-		List<Comment> comments = commentRepository.findByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(postId);
+		List<Comment> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId);
 		List<CommentsInPost> commentTree = CommentTreeBuilder.build(comments);
 
 		return PostDetailResponse.builder()

--- a/backend/src/main/java/org/juniortown/backend/user/exception/UserNotFoundException.java
+++ b/backend/src/main/java/org/juniortown/backend/user/exception/UserNotFoundException.java
@@ -4,7 +4,7 @@ import org.juniortown.backend.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
 public class UserNotFoundException extends CustomException {
-	private static final String MESSAGE = "해당 사용자를 찾을 수 없습니다.";
+	public static final String MESSAGE = "해당 사용자를 찾을 수 없습니다.";
 	public UserNotFoundException() {
 		super(MESSAGE);
 	}

--- a/backend/src/test/java/org/juniortown/backend/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/controller/CommentControllerTest.java
@@ -16,6 +16,7 @@ import org.juniortown.backend.comment.exception.AlreadyDeletedCommentException;
 import org.juniortown.backend.comment.exception.CommentNotFoundException;
 import org.juniortown.backend.comment.exception.DepthLimitTwoException;
 import org.juniortown.backend.comment.exception.NoRightForCommentDeleteException;
+import org.juniortown.backend.comment.exception.NoRightForCommentUpdateException;
 import org.juniortown.backend.comment.exception.ParentPostMismatchException;
 import org.juniortown.backend.comment.repository.CommentRepository;
 import org.juniortown.backend.config.RedisTestConfig;
@@ -563,7 +564,7 @@ class CommentControllerTest {
 				.content(objectMapper.writeValueAsString(commentUpdateRequest))
 			)
 			.andExpect(status().isForbidden())
-			.andExpect(jsonPath("$.message").value(NoRightForCommentDeleteException.MESSAGE))
+			.andExpect(jsonPath("$.message").value(NoRightForCommentUpdateException.MESSAGE))
 			.andDo(print());
 	}
 

--- a/backend/src/test/java/org/juniortown/backend/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/controller/CommentControllerTest.java
@@ -30,6 +30,7 @@ import org.juniortown.backend.user.repository.UserRepository;
 import org.juniortown.backend.user.request.SignUpDTO;
 import org.juniortown.backend.user.service.AuthService;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -76,7 +77,7 @@ class CommentControllerTest {
 	private final static String COMMENT_CONTENT_NOT_EMPTY = "댓글 내용을 입력해주세요.";
 	private final static String POST_ID_NOT_EMPTY = "게시글 ID를 입력해주세요.";
 
-	@BeforeAll
+	@BeforeEach
 	public void init() throws Exception {
 		UUID uuid = UUID.randomUUID();
 		String email = uuid + "@naver.com";

--- a/backend/src/test/java/org/juniortown/backend/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/controller/CommentControllerTest.java
@@ -1,0 +1,297 @@
+package org.juniortown.backend.comment.controller;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
+import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
+import org.juniortown.backend.comment.entity.Comment;
+import org.juniortown.backend.comment.repository.CommentRepository;
+import org.juniortown.backend.config.RedisTestConfig;
+import org.juniortown.backend.config.SyncConfig;
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.post.repository.PostRepository;
+import org.juniortown.backend.user.dto.LoginDTO;
+import org.juniortown.backend.user.entity.User;
+import org.juniortown.backend.user.jwt.JWTUtil;
+import org.juniortown.backend.user.repository.UserRepository;
+import org.juniortown.backend.user.request.SignUpDTO;
+import org.juniortown.backend.user.service.AuthService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
+@Import({RedisTestConfig.class, SyncConfig.class})
+@Transactional
+class CommentControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private PostRepository postRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private CommentRepository commentRepository;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private AuthService authService;
+	@Autowired
+	private JWTUtil jwtUtil;
+	private static String jwt;
+	private User testUser;
+	private Post post;
+
+	private final static Long ID_NOT_EXIST = 999999L;
+
+	@BeforeAll
+	public void init() throws Exception {
+		UUID uuid = UUID.randomUUID();
+		String email = uuid + "@naver.com";
+		SignUpDTO signUpDTO = SignUpDTO.builder()
+			.email(email)
+			.password("1234")
+			.username("테스터")
+			.build();
+
+		LoginDTO loginDTO = LoginDTO.builder()
+			.email(signUpDTO.getEmail())
+			.password(signUpDTO.getPassword())
+			.build();
+		authService.signUp(signUpDTO);
+		testUser = userRepository.findByEmail(email).get();
+
+		// 로그인 후 JWT 토큰을 발급받는다.
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(loginDTO))
+			)
+			.andExpect(status().isOk())
+			.andDo(result -> {
+				jwt = result.getResponse().getHeader("Authorization");
+			});
+
+		// 게시글을 하나 생성한다.
+		post = postRepository.save(
+			Post.builder()
+				.title("테스트 게시글")
+				.content("테스트 내용입니다.")
+				.user(testUser)
+				.build()
+		);
+		postRepository.save(post);
+	}
+
+	@Test
+	@DisplayName("댓글 생성 성공")
+	void create_comment_success() throws Exception {
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(post.getId())
+			.parentId(null) // 최상위 댓글인 경우 null
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.commentId").exists())
+			.andExpect(jsonPath("$.content").value("테스트 댓글"))
+			.andExpect(jsonPath("$.postId").value(post.getId()))
+			.andExpect(jsonPath("$.parentId").doesNotExist())
+			.andExpect(jsonPath("$.userId").value(testUser.getId()))
+			.andExpect(jsonPath("$.username").value(testUser.getName()))
+			.andExpect(jsonPath("$.createdAt").exists())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("대댓글 생성 성공")
+	void create_child_comment_success() throws Exception {
+		Comment parentComment = Comment.builder()
+			.content("부모 댓글")
+			.post(post)
+			.user(testUser)
+			.username(testUser.getName())
+			.build();
+		parentComment = commentRepository.save(parentComment);
+
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(post.getId())
+			.parentId(parentComment.getId()) // 부모 댓글 ID
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.commentId").exists())
+			.andExpect(jsonPath("$.content").value("테스트 댓글"))
+			.andExpect(jsonPath("$.postId").value(post.getId()))
+			.andExpect(jsonPath("$.parentId").value(parentComment.getId()))
+			.andExpect(jsonPath("$.userId").value(testUser.getId()))
+			.andExpect(jsonPath("$.username").value(testUser.getName()))
+			.andExpect(jsonPath("$.createdAt").exists())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 - 게시글이 존재하지 않음")
+	void create_comment_fail_with_no_post() throws Exception {
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(ID_NOT_EXIST)
+			.parentId(null) // 최상위 댓글인 경우 null
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("해당 게시글을 찾을 수 없습니다."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 - 유저가 존재하지 않음")
+	void create_comment_fail_with_no_user() throws Exception {
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(post.getId())
+			.parentId(null) // 최상위 댓글인 경우 null
+			.build();
+		userRepository.deleteById(testUser.getId()); // 유저 삭제
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("해당 사용자를 찾을 수 없습니다."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 - 부모 댓글과 자식 댓글의 게시글이 다름")
+	void create_comment_fail_with_not_same_post() throws Exception {
+		Post dummyPost = Post.builder()
+			.title("다른 게시글")
+			.content("다른 게시글 내용입니다.")
+			.user(testUser)
+			.build();
+		Post savedDummyPost = postRepository.save(dummyPost);
+
+		Comment parentComment = Comment.builder()
+			.content("부모 댓글")
+			.post(savedDummyPost)
+			.user(testUser)
+			.username(testUser.getName())
+			.build();
+		Comment savedParentComment = commentRepository.save(parentComment);
+
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(post.getId())
+			.parentId(savedParentComment.getId()) // 최상위 댓글인 경우 null
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("부모 댓글의 게시글과 대댓글이 속한 게시글이 일치하지 않습니다."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 - 부모 댓글이 존재하지 않음.")
+	void create_comment_fail_with_parent_comment_not_exist() throws Exception {
+		Comment parentComment = Comment.builder()
+			.content("부모 댓글")
+			.post(post)
+			.user(testUser)
+			.username(testUser.getName())
+			.build();
+		Comment savedParentComment = commentRepository.save(parentComment);
+
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(post.getId())
+			.parentId(ID_NOT_EXIST) // 최상위 댓글인 경우 null
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("해당 댓글을 찾을 수 없습니다."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 - content가 비어있음")
+	void create_comment_fail_empty_content() throws Exception {
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("")
+			.postId(post.getId())
+			.parentId(null) // 최상위 댓글인 경우 null
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.validation.content").value("댓글 내용을 입력해주세요."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 - postId가 비어있음")
+	void create_comment_fail_empty_post_id() throws Exception {
+		CommentCreateRequest commentRequest = CommentCreateRequest.builder()
+			.content("테스트 댓글")
+			.postId(null)
+			.parentId(null) // 최상위 댓글인 경우 null
+			.build();
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/comments")
+				.contentType(APPLICATION_JSON)
+				.header("Authorization", jwt)
+				.content(objectMapper.writeValueAsString(commentRequest))
+			)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.validation.postId").value("게시글 ID를 입력해주세요."))
+			.andDo(print());
+	}
+}

--- a/backend/src/test/java/org/juniortown/backend/comment/entity/CommentTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/entity/CommentTest.java
@@ -1,0 +1,29 @@
+package org.juniortown.backend.comment.entity;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommentTest {
+	@Test
+	@DisplayName("Comment 생성 시 기본 값 설정 확인")
+	void softDelete_setsDeletedAt() {
+		// given
+		Comment comment = Comment.builder()
+			.content("Test comment")
+			.build();
+		Clock fixedClock = Clock.fixed(
+			Instant.parse("2025-06-20T10:15:30Z"), ZoneOffset.UTC);
+		// when
+		comment.softDelete(fixedClock);
+
+		// then
+		Assertions.assertThat(comment.getDeletedAt())
+			.isEqualTo(LocalDateTime.now(fixedClock));
+	}
+
+}

--- a/backend/src/test/java/org/juniortown/backend/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/service/CommentServiceTest.java
@@ -1,0 +1,223 @@
+package org.juniortown.backend.comment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Clock;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.juniortown.backend.comment.dto.request.CommentCreateRequest;
+import org.juniortown.backend.comment.dto.response.CommentCreateResponse;
+import org.juniortown.backend.comment.entity.Comment;
+import org.juniortown.backend.comment.exception.CommentNotFoundException;
+import org.juniortown.backend.comment.exception.ParentPostMismatchException;
+import org.juniortown.backend.comment.repository.CommentRepository;
+import org.juniortown.backend.post.dto.request.PostCreateRequest;
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.post.repository.PostRepository;
+import org.juniortown.backend.user.entity.User;
+import org.juniortown.backend.user.exception.UserNotFoundException;
+import org.juniortown.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class CommentServiceTest {
+	@InjectMocks
+	private CommentService commentService;
+	@Mock
+	private CommentRepository commentRepository;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private PostRepository postRepository;
+	@Mock
+	private Clock clock;
+	@Mock
+	private Post post;
+	@Mock
+	private User user;
+	@Mock
+	private Comment comment;
+	static final Long USER_ID = 3L;
+	static final Long POST_ID = 1L;
+	static final Long COMMENT_ID = 5L;
+	static final String USERNAME = "testUser";
+
+	@Test
+	@DisplayName("댓글 생성 성공 테스트")
+	void create_comment_success() {
+		// given
+		Long parentId = null;
+		String content = "This is a comment";
+		CommentCreateRequest commentCreateRequest = CommentCreateRequest.builder()
+			.content(content)
+			.postId(POST_ID)
+			.parentId(parentId)
+			.build();
+
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+		when(postRepository.findById(POST_ID)).thenReturn(Optional.of(post));
+		when(user.getName()).thenReturn(USERNAME);
+		when(user.getId()).thenReturn(USER_ID);
+		when(post.getId()).thenReturn(POST_ID);
+
+		when(commentRepository.save(any())).thenReturn(comment);
+		when(comment.getId()).thenReturn(COMMENT_ID);
+		when(comment.getContent()).thenReturn(content);
+		when(comment.getPost()).thenReturn(post);
+		when(comment.getParent()).thenReturn(null);
+		when(comment.getUser()).thenReturn(user);
+
+		// when
+		CommentCreateResponse response = commentService.createComment(USER_ID, commentCreateRequest);
+
+		// then
+		verify(commentRepository).save(any());
+		Assertions.assertThat(response.getContent()).isEqualTo(content);
+		Assertions.assertThat(response.getPostId()).isEqualTo(POST_ID);
+		Assertions.assertThat(response.getParentId()).isNull();
+		Assertions.assertThat(response.getUserId()).isEqualTo(USER_ID);
+		Assertions.assertThat(response.getUsername()).isEqualTo(user.getName());
+	}
+
+	@Test
+	@DisplayName("대댓글 생성 성공 테스트")
+	void create_child_comment_success() {
+		// given
+		Long parentId = 2L;
+		String content = "This is a comment";
+		CommentCreateRequest commentCreateRequest = CommentCreateRequest.builder()
+			.content(content)
+			.postId(POST_ID)
+			.parentId(parentId)
+			.build();
+
+		Comment parentComment = mock(Comment.class);
+		when(parentComment.getId()).thenReturn(parentId);
+		when(commentRepository.findById(parentId)).thenReturn(Optional.of(parentComment));
+		when(parentComment.getPost()).thenReturn(post);
+
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+		when(postRepository.findById(POST_ID)).thenReturn(Optional.of(post));
+		when(user.getName()).thenReturn(USERNAME);
+		when(user.getId()).thenReturn(USER_ID);
+		when(post.getId()).thenReturn(POST_ID);
+
+		when(commentRepository.save(any())).thenReturn(comment);
+		when(comment.getId()).thenReturn(COMMENT_ID);
+		when(comment.getContent()).thenReturn(content);
+		when(comment.getPost()).thenReturn(post);
+		when(comment.getParent()).thenReturn(null);
+		when(comment.getUser()).thenReturn(user);
+		when(comment.getParent()).thenReturn(parentComment);
+
+		// when
+		CommentCreateResponse response = commentService.createComment(USER_ID, commentCreateRequest);
+
+		// then
+		verify(commentRepository).save(any());
+		Assertions.assertThat(response.getContent()).isEqualTo(content);
+		Assertions.assertThat(response.getPostId()).isEqualTo(POST_ID);
+		Assertions.assertThat(response.getUserId()).isEqualTo(USER_ID);
+		Assertions.assertThat(response.getUsername()).isEqualTo(user.getName());
+		Assertions.assertThat(response.getParentId()).isEqualTo(parentId);
+	}
+
+	@Test
+	@DisplayName("대댓글 생성 실패 테스트 - 부모 댓글이 다른 게시글에 속함")
+	void create_child_comment_fail_by_parent_child_comments_have_different_post() {
+		// given
+		Long parentId = 2L;
+		String content = "This is a comment";
+		CommentCreateRequest commentCreateRequest = CommentCreateRequest.builder()
+			.content(content)
+			.postId(POST_ID)
+			.parentId(parentId)
+			.build();
+
+		Comment parentComment = mock(Comment.class);
+		Post otherPost = mock(Post.class);
+		when(commentRepository.findById(parentId)).thenReturn(Optional.of(parentComment));
+		when(parentComment.getPost()).thenReturn(otherPost);
+
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+		when(postRepository.findById(POST_ID)).thenReturn(Optional.of(post));
+
+		// when, then
+		verify(commentRepository, never()).save(any(Comment.class));
+		// 예외 터진거 확인은 어떻게 해?
+		Assertions.assertThatThrownBy(() -> commentService.createComment(USER_ID, commentCreateRequest))
+			.isInstanceOf(ParentPostMismatchException.class)
+			.hasMessage("부모 댓글의 게시글과 대댓글이 속한 게시글이 일치하지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 테스트 - 사용자 존재하지 않음")
+	void create_child_comment_fail_by_no_user() {
+		// given
+		Long parentId = 2L;
+		String content = "This is a comment";
+		CommentCreateRequest commentCreateRequest = CommentCreateRequest.builder()
+			.content(content)
+			.postId(POST_ID)
+			.parentId(parentId)
+			.build();
+
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.ofNullable(null));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> commentService.createComment(USER_ID, commentCreateRequest))
+			.isInstanceOf(UserNotFoundException.class)
+			.hasMessage("해당 사용자를 찾을 수 없습니다.");
+	}
+	@Test
+	@DisplayName("댓글 생성 실패 테스트 - 게시글 존재하지 않음")
+	void create_child_comment_fail_by_no_post() {
+		// given
+		Long parentId = 2L;
+		String content = "This is a comment";
+		CommentCreateRequest commentCreateRequest = CommentCreateRequest.builder()
+			.content(content)
+			.postId(POST_ID)
+			.parentId(parentId)
+			.build();
+
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.ofNullable(null));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> commentService.createComment(USER_ID, commentCreateRequest))
+			.isInstanceOf(UserNotFoundException.class)
+			.hasMessage("해당 사용자를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("댓글 생성 실패 테스트 - 부모 댓글이 존재하지 않음")
+	void create_child_comment_fail_by_parent_post_not_exist() {
+		// given
+		Long parentId = 2L;
+		String content = "This is a comment";
+		CommentCreateRequest commentCreateRequest = CommentCreateRequest.builder()
+			.content(content)
+			.postId(POST_ID)
+			.parentId(parentId)
+			.build();
+
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+		when(postRepository.findById(POST_ID)).thenReturn(Optional.of(post));
+		when(commentRepository.findById(parentId)).thenReturn(Optional.empty());
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> commentService.createComment(USER_ID, commentCreateRequest))
+			.isInstanceOf(CommentNotFoundException.class)
+			.hasMessage("해당 댓글을 찾을 수 없습니다.");
+
+	}
+}

--- a/backend/src/test/java/org/juniortown/backend/comment/service/CommentTreeBuilderTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/service/CommentTreeBuilderTest.java
@@ -31,10 +31,10 @@ class CommentTreeBuilderTest {
 		userA = createUser(1L, "testA", "testA@gmail.com");
 		userB = createUser(2L, "testB", "testB@gmail.com");
 		post = createPost(1L, "테스트 게시글", "테스트 게시글 내용", userA);
-		parentComment1 = commentCreate(1L, post, userA, "부모 댓글1", null);
-		parentComment2 = commentCreate(2L, post, userB, "부모 댓글2", null);
-		childComment1 = commentCreate(3L, post, userA, "자식 댓글1", parentComment1);
-		childComment2 = commentCreate(4L, post, userB, "자식 댓글2", parentComment2);
+		parentComment1 = createComment(1L, post, userA, "부모 댓글1", null);
+		parentComment2 = createComment(2L, post, userB, "부모 댓글2", null);
+		childComment1 = createComment(3L, post, userA, "자식 댓글1", parentComment1);
+		childComment2 = createComment(4L, post, userB, "자식 댓글2", parentComment2);
 	}
 	@Test
 	@DisplayName("빈 리스트 주입 시 빈 리스트 반환")

--- a/backend/src/test/java/org/juniortown/backend/comment/service/CommentTreeBuilderTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/service/CommentTreeBuilderTest.java
@@ -1,0 +1,79 @@
+package org.juniortown.backend.comment.service;
+
+import static org.juniortown.backend.util.TestDataUtil.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.juniortown.backend.comment.dto.response.CommentsInPost;
+import org.juniortown.backend.comment.entity.Comment;
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentTreeBuilderTest {
+	private User userA;
+	private User userB;
+	private Post post;
+	private Comment parentComment1;
+	private Comment parentComment2;
+	private Comment childComment1;
+	private Comment childComment2;
+
+	@BeforeEach
+	void setUp() {
+		userA = createUser(1L, "testA", "testA@gmail.com");
+		userB = createUser(2L, "testB", "testB@gmail.com");
+		post = createPost(1L, "테스트 게시글", "테스트 게시글 내용", userA);
+		parentComment1 = commentCreate(1L, post, userA, "부모 댓글1", null);
+		parentComment2 = commentCreate(2L, post, userB, "부모 댓글2", null);
+		childComment1 = commentCreate(3L, post, userA, "자식 댓글1", parentComment1);
+		childComment2 = commentCreate(4L, post, userB, "자식 댓글2", parentComment2);
+	}
+	@Test
+	@DisplayName("빈 리스트 주입 시 빈 리스트 반환")
+	void build_emptyList_returnsEmptyList() {
+		assertTrue(CommentTreeBuilder.build(List.of()).isEmpty());
+	}
+
+	@Test
+	@DisplayName("부모가 없는 댓글들만 주입 시 부모가 없는 댓글들만 반환")
+	void build_no_parentComments_returns_only_root_comments() {
+		List<CommentsInPost> comments = CommentTreeBuilder.build(List.of(
+			parentComment1, parentComment2
+		));
+		Assertions.assertThat(comments.size()).isEqualTo(2);
+		Assertions.assertThat(comments.get(0).getChildren()).isEmpty();
+		Assertions.assertThat(comments.get(1).getChildren()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("부모가 있는 댓글들만 주입 시 반환 안함.")
+	void build_only_childComments_returns_nothing() {
+		List<CommentsInPost> comments = CommentTreeBuilder.build(List.of(
+			childComment1, childComment2
+		));
+		Assertions.assertThat(comments).isEmpty();
+	}
+
+	@Test
+	@DisplayName("부모 댓글과 자식 댓글을 주입 시 트리 구조로 반환")
+	void build_parentAndChildComments_returns_tree_structure() {
+		List<CommentsInPost> comments = CommentTreeBuilder.build(List.of(
+			parentComment1, parentComment2, childComment1, childComment2
+		));
+		Assertions.assertThat(comments.size()).isEqualTo(2);
+		Assertions.assertThat(comments.get(0).getChildren().size()).isEqualTo(1);
+		Assertions.assertThat(comments.get(1).getChildren().size()).isEqualTo(1);
+		Assertions.assertThat(comments.get(0).getChildren().get(0).getContent()).isEqualTo("자식 댓글1");
+		Assertions.assertThat(comments.get(1).getChildren().get(0).getContent()).isEqualTo("자식 댓글2");
+	}
+
+
+}

--- a/backend/src/test/java/org/juniortown/backend/config/TestClockConfig.java
+++ b/backend/src/test/java/org/juniortown/backend/config/TestClockConfig.java
@@ -1,0 +1,18 @@
+package org.juniortown.backend.config;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+@Primary
+public class TestClockConfig {
+	@Bean
+	public Clock clock() {
+		return Clock.fixed(Instant.parse("2025-06-20T10:15:30Z"), ZoneOffset.UTC);
+	}
+}

--- a/backend/src/test/java/org/juniortown/backend/config/TestClockNotMockConfig.java
+++ b/backend/src/test/java/org/juniortown/backend/config/TestClockNotMockConfig.java
@@ -1,0 +1,13 @@
+package org.juniortown.backend.config;
+
+import java.time.Clock;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+@TestConfiguration
+public class TestClockNotMockConfig {
+	@Bean
+	public Clock clock() {
+		return Clock.systemUTC();
+	}
+}

--- a/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.config.SyncConfig;
+import org.juniortown.backend.config.TestClockConfig;
 import org.juniortown.backend.user.dto.LoginDTO;
 import org.juniortown.backend.user.jwt.JWTUtil;
 import org.juniortown.backend.user.repository.UserRepository;
@@ -25,13 +26,15 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import({RedisTestConfig.class,SyncConfig.class})
+@Import({RedisTestConfig.class,SyncConfig.class, TestClockConfig.class})
+@Transactional
 class AuthControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
@@ -43,11 +46,6 @@ class AuthControllerTest {
 	private ObjectMapper objectMapper;
 	@Autowired
 	private JWTUtil jwtUtil;
-
-	@AfterEach
-	void clean() {
-		userRepository.deleteAll();
-	}
 
 	@BeforeEach
 	public void init() {

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
@@ -61,7 +61,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 class PostControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
-
 	@Autowired
 	private PostRepository postRepository;
 	@Autowired
@@ -72,11 +71,6 @@ class PostControllerTest {
 	private AuthService authService;
 	@Autowired
 	private JWTUtil jwtUtil;
-
-	@BeforeEach
-	void clean() {
-		postRepository.deleteAll();
-	}
 
 	private static String jwt;
 	private User testUser;

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
@@ -14,6 +14,7 @@ import java.util.stream.IntStream;
 
 import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.config.SyncConfig;
+import org.juniortown.backend.config.TestClockConfig;
 import org.juniortown.backend.post.dto.request.PostCreateRequest;
 import org.juniortown.backend.post.entity.Post;
 import org.juniortown.backend.post.repository.PostRepository;
@@ -56,7 +57,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ActiveProfiles("test")
-@Import({RedisTestConfig.class, SyncConfig.class})
+@Import({RedisTestConfig.class, SyncConfig.class, TestClockConfig.class})
 @Transactional
 class PostControllerTest {
 	@Autowired

--- a/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostRedisReadControllerTest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.juniortown.backend.config.RedisTestConfig;
+import org.juniortown.backend.config.TestClockConfig;
 import org.juniortown.backend.post.entity.Post;
 import org.juniortown.backend.post.repository.PostRepository;
 import org.juniortown.backend.post.service.ViewCountSyncService;
@@ -54,7 +55,7 @@ import jakarta.servlet.http.Cookie;
 @ActiveProfiles("test")
 @Transactional
 @Testcontainers
-@Import(RedisTestConfig.class)
+@Import({RedisTestConfig.class, TestClockConfig.class})
 public class PostRedisReadControllerTest {
 	@Autowired
 	private MockMvc mockMvc;

--- a/backend/src/test/java/org/juniortown/backend/like/controller/LikeControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/like/controller/LikeControllerTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import org.juniortown.backend.config.RedisTestConfig;
 import org.juniortown.backend.config.SyncConfig;
+import org.juniortown.backend.config.TestClockConfig;
 import org.juniortown.backend.like.entity.Like;
 import org.juniortown.backend.like.exception.LikeFailureException;
 import org.juniortown.backend.like.repository.LikeRepository;
@@ -37,7 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import({RedisTestConfig.class, SyncConfig.class})
+@Import({RedisTestConfig.class, SyncConfig.class, TestClockConfig.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // 클래스 단위로 테스트 인스턴스를 생성한다.
 @Transactional
 class LikeControllerTest {

--- a/backend/src/test/java/org/juniortown/backend/post/entity/PostTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/entity/PostTest.java
@@ -1,9 +1,7 @@
 package org.juniortown.backend.post.entity;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.sql.Time;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -15,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class PostTest {
 	@Test
-	@DisplayName("Post 생성 시 기본 값 설정 확인")
+	@DisplayName("Post 삭제 시 기본 값 설정 확인")
 	void softDelete_setsDeletedAt() {
 		// given
 		Post post = Post.builder().title("T").content("C").build();
@@ -27,8 +25,7 @@ class PostTest {
 
 		// then
 		assertEquals(post.getDeletedAt(),
-			LocalDateTime.ofInstant(Instant.parse("2025-06-20T10:15:30Z"),
-				ZoneOffset.UTC));
+			LocalDateTime.now(fixedClock));
 	}
 
 	@Test

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -286,7 +286,7 @@ class PostServiceTest {
 		// when
 		//when(user.getId()).thenReturn(userId);
 		when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
-		when(commentRepository.findByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(postId))
+		when(commentRepository.findByPostIdOrderByCreatedAtAsc(postId))
 			.thenReturn(List.of(parentComment1, parentComment2, childComment1, childComment2));
 
 		PostDetailResponse result = postService.getPost(postId, String.valueOf(userId));

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -277,10 +277,10 @@ class PostServiceTest {
 		String name = "testName";
 		user = createUser(userId, name,  "test@email.com");
 		post = createPost(postId, title, content, user);
-		Comment parentComment1 = commentCreate(1L, post, user, "부모 댓글1", null);
-		Comment parentComment2 = commentCreate(2L, post, user, "부모 댓글2", null);
-		Comment childComment1 = commentCreate(3L, post, user, "자식 댓글1", parentComment1);
-		Comment childComment2 = commentCreate(4L, post, user, "자식 댓글2", parentComment2);
+		Comment parentComment1 = createComment(1L, post, user, "부모 댓글1", null);
+		Comment parentComment2 = createComment(2L, post, user, "부모 댓글2", null);
+		Comment childComment1 = createComment(3L, post, user, "자식 댓글1", parentComment1);
+		Comment childComment2 = createComment(4L, post, user, "자식 댓글2", parentComment2);
 
 
 		// when

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -61,11 +61,6 @@ class PostServiceTest {
 	@Mock
 	private ValueOperations<String, Long> readCountValueOperations;
 
-	@BeforeEach
-	void clear() {
-		postRepository.deleteAll();
-	}
-
 	@Test
 	@DisplayName("게시글 생성 성공")
 	void createPost_success() {

--- a/backend/src/test/java/org/juniortown/backend/util/TestDataUtil.java
+++ b/backend/src/test/java/org/juniortown/backend/util/TestDataUtil.java
@@ -1,0 +1,38 @@
+package org.juniortown.backend.util;
+
+import org.juniortown.backend.comment.entity.Comment;
+import org.juniortown.backend.post.entity.Post;
+import org.juniortown.backend.user.entity.User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TestDataUtil {
+	public static Comment commentCreate(Long id, Post post, User user, String content, Comment parentComment) {
+		Comment comment = Comment.builder()
+			.post(post)
+			.user(user)
+			.username(user.getName())
+			.content(content)
+			.parent(parentComment)
+			.build();
+		ReflectionTestUtils.setField(comment, "id", id);
+		return comment;
+	}
+	public static Post createPost(Long id,String title,String content, User user) {
+		Post post = Post.builder()
+			.title(title)
+			.content(content)
+			.user(user)
+			.build();
+		ReflectionTestUtils.setField(post, "id", id);
+		return post;
+	}
+	public static User createUser(Long id, String name,String email) {
+		User user = User.builder()
+			.name(name)
+			.password("password")
+			.email(email)
+			.build();
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+}

--- a/backend/src/test/java/org/juniortown/backend/util/TestDataUtil.java
+++ b/backend/src/test/java/org/juniortown/backend/util/TestDataUtil.java
@@ -6,7 +6,7 @@ import org.juniortown.backend.user.entity.User;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class TestDataUtil {
-	public static Comment commentCreate(Long id, Post post, User user, String content, Comment parentComment) {
+	public static Comment createComment(Long id, Post post, User user, String content, Comment parentComment) {
 		Comment comment = Comment.builder()
 			.post(post)
 			.user(user)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.9.0",
+        "base-64": "^1.0.0",
         "bootstrap": "^5.3.6",
         "http-proxy-middleware": "^3.0.5",
         "react": "^19.1.0",
@@ -4927,6 +4928,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/batch": {
       "version": "0.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.9.0",
+    "base-64": "^1.0.0",
     "bootstrap": "^5.3.6",
     "http-proxy-middleware": "^3.0.5",
     "react": "^19.1.0",

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Form, Card } from 'react-bootstrap';
 import axios from 'axios';
-export default CommentSection;
+
 
 function CommentSection({ postId, comments, myUserId, refreshPost }) {
   // 댓글 입력/수정 상태
@@ -246,4 +246,4 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
   );
 };
 
-
+export default CommentSection;

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -1,0 +1,247 @@
+import React, { useState } from 'react';
+import { Button, Form, Card } from 'react-bootstrap';
+import axios from 'axios';
+export default CommentSection;
+
+function CommentSection({ postId, comments, myUserId, refreshPost }) {
+  // 댓글 입력/수정 상태
+  const [commentContent, setCommentContent] = useState('');
+  const [replyContent, setReplyContent] = useState('');
+  const [editingId, setEditingId] = useState(null); // 수정 중인 댓글 id
+  const [editingContent, setEditingContent] = useState('');
+  const [replyParentId, setReplyParentId] = useState(null); // 대댓글 입력창 표시용 parent id
+
+  // 댓글 등록
+  const handleCommentSubmit = async (e) => {
+    e.preventDefault();
+    if (!commentContent.trim()) return;
+    try {
+      const token = localStorage.getItem('jwt');
+      await axios.post('/api/comments', {
+        postId,
+        content: commentContent,
+        parentId: null,
+      }, { headers: { Authorization: token } });
+      setCommentContent('');
+      refreshPost(); // 게시글 및 댓글 데이터 새로고침
+    } catch (err) {
+      alert('댓글 등록 실패');
+    }
+  };
+
+  // 대댓글 등록
+  const handleReplySubmit = async (e, parentId) => {
+    e.preventDefault();
+    if (!replyContent.trim()) return;
+    try {
+      const token = localStorage.getItem('jwt');
+      await axios.post('/api/comments', {
+        postId,
+        content: replyContent,
+        parentId,
+      }, { headers: { Authorization: token } });
+      setReplyContent('');
+      setReplyParentId(null);
+      refreshPost();
+    } catch (err) {
+      alert('대댓글 등록 실패');
+    }
+  };
+
+  // 댓글 삭제
+  const handleDelete = async (commentId) => {
+    if (!window.confirm('댓글을 삭제할까요?')) return;
+    try {
+      const token = localStorage.getItem('jwt');
+      await axios.delete(`/api/comments/${commentId}`, {
+        headers: { Authorization: token },
+      });
+      refreshPost();
+    } catch (err) {
+      alert('댓글 삭제 실패');
+    }
+  };
+
+  // 댓글 수정
+  const handleEditSubmit = async (e, commentId) => {
+    e.preventDefault();
+    if (!editingContent.trim()) return;
+    try {
+      const token = localStorage.getItem('jwt');
+      await axios.patch(`/api/comments/${commentId}`, {
+        content: editingContent,
+      }, { headers: { Authorization: token } });
+      setEditingId(null);
+      setEditingContent('');
+      refreshPost();
+    } catch (err) {
+      alert('댓글 수정 실패');
+    }
+  };
+
+  // 트리형 댓글 렌더링
+  const renderComments = (commentList, depth = 0) =>
+    commentList.map((comment) => (
+      <div key={comment.commentId} style={{ marginLeft: depth * 24, marginTop: 12 }}>
+        <Card className="mb-1">
+          <Card.Body className="py-2 px-3">
+            <div className="d-flex justify-content-between align-items-center">
+              <span>
+                <b>{comment.username}</b>{" "}
+                <small className="text-muted">
+                  {new Date(comment.createdAt).toLocaleString("ko-KR")}
+                </small>
+                <small className="text-muted ms-2">
+                  {comment.createdAt !== comment.updatedAt && comment.deletedAt === null && " (수정됨)"}
+                </small>
+              </span>
+              {/* 내 댓글만 수정/삭제 */}
+              {!comment.deletedAt && myUserId && myUserId === comment.userId && (
+                <span>
+                  {editingId === comment.commentId ? null : (
+                    <>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        onClick={(e) => {
+                          setEditingId(comment.commentId);
+                          setEditingContent(comment.content);
+                        }}
+                        style={{ textDecoration: 'underline', color: '#0d6efd' }}
+                      >
+                        수정
+                      </Button>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        onClick={() => handleDelete(comment.commentId)}
+                        style={{ textDecoration: 'underline', color: '#dc3545' }}
+                      >
+                        삭제
+                      </Button>
+                    </>
+                  )}
+                </span>
+              )}
+            </div>
+            {/* 댓글 내용 or 수정폼 */}
+            {editingId === comment.commentId ? (
+              <Form
+                className="mt-2"
+                onSubmit={(e) => handleEditSubmit(e, comment.commentId)}
+              >
+                <Form.Control
+                  as="textarea"
+                  size="sm"
+                  value={editingContent}
+                  onChange={(e) => setEditingContent(e.target.value)}
+                  rows={2}
+                  className="mb-2"
+                />
+                <div className="d-flex">
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    size="sm"
+                    className="me-2"
+                  >
+                    저장
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setEditingId(null)}
+                  >
+                    취소
+                  </Button>
+                </div>
+              </Form>
+            ) : (
+              <div style={{ whiteSpace: 'pre-wrap', color: comment.deletedAt ? '#adb5bd' : undefined }}>
+                {comment.deletedAt ? '삭제된 댓글입니다.' : comment.content}
+              </div>
+            )}
+
+            {/* 대댓글 입력창 */}
+            {!comment.deletedAt && (
+              <>
+                {replyParentId === comment.commentId ? (
+                  <Form
+                    className="mt-2"
+                    onSubmit={(e) => handleReplySubmit(e, comment.commentId)}
+                  >
+                    <Form.Control
+                      as="textarea"
+                      size="sm"
+                      value={replyContent}
+                      onChange={(e) => setReplyContent(e.target.value)}
+                      rows={2}
+                      className="mb-2"
+                      placeholder="대댓글을 입력하세요"
+                    />
+                    <div className="d-flex">
+                      <Button
+                        type="submit"
+                        variant="success"
+                        size="sm"
+                        className="me-2"
+                      >
+                        등록
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => setReplyParentId(null)}
+                      >
+                        취소
+                      </Button>
+                    </div>
+                  </Form>
+                ) : (
+                  <Button
+                    variant="outline-secondary"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => setReplyParentId(comment.commentId)}
+                  >
+                    답글
+                  </Button>
+                )}
+              </>
+            )}
+          </Card.Body>
+        </Card>
+        {/* 대댓글 트리 재귀 */}
+        {comment.children && comment.children.length > 0 &&
+          renderComments(comment.children, depth + 1)}
+      </div>
+    ));
+
+  return (
+    <div className="mt-4">
+      {/* 댓글 입력 폼 */}
+      <Form onSubmit={handleCommentSubmit} className="mb-3">
+        <Form.Group controlId="commentContent" className="d-flex">
+          <Form.Control
+            as="textarea"
+            rows={2}
+            value={commentContent}
+            onChange={(e) => setCommentContent(e.target.value)}
+            placeholder="댓글을 입력하세요"
+          />
+          <Button type="submit" variant="primary" className="ms-2" style={{ minWidth: 80 }}>
+            등록
+          </Button>
+        </Form.Group>
+      </Form>
+      {/* 댓글 목록 */}
+      {comments && comments.length > 0 ? (
+        renderComments(comments)
+      ) : (
+        <div className="text-muted">아직 댓글이 없습니다.</div>
+      )}
+    </div>
+  );
+};
+
+

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -25,7 +25,8 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
       setCommentContent('');
       refreshPost(); // 게시글 및 댓글 데이터 새로고침
     } catch (err) {
-      alert('댓글 등록 실패');
+      console.error('댓글 등록 실패:', err);
+      alert(`댓글 등록 실패: ${err.response?.data?.message || '알 수 없는 오류가 발생했습니다.'}`);
     }
   };
 
@@ -44,7 +45,8 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
       setReplyParentId(null);
       refreshPost();
     } catch (err) {
-      alert('대댓글 등록 실패');
+      console.error('대댓글 등록 실패:', err);
+      alert(`댓글 등록 실패: ${err.response?.data?.message || '알 수 없는 오류가 발생했습니다.'}`);
     }
   };
 
@@ -58,7 +60,8 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
       });
       refreshPost();
     } catch (err) {
-      alert('댓글 삭제 실패');
+      console.error('댓글 삭제 실패:', err);
+      alert(`댓글 삭제 실패: ${err.response?.data?.message || '알 수 없는 오류가 발생했습니다.'}`);
     }
   };
 
@@ -75,7 +78,8 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
       setEditingContent('');
       refreshPost();
     } catch (err) {
-      alert('댓글 수정 실패');
+      console.error('댓글 수정 실패:', err);
+      alert(`댓글 수정 실패: ${err.response?.data?.message || '알 수 없는 오류가 발생했습니다.'}`);
     }
   };
 

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -106,6 +106,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
                         onClick={(e) => {
                           setEditingId(comment.commentId);
                           setEditingContent(comment.content);
+                          setReplyParentId(null); // 대댓글 입력창 닫기
                         }}
                         style={{ textDecoration: 'underline', color: '#0d6efd' }}
                       >
@@ -163,7 +164,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
             )}
 
             {/* 대댓글 입력창 */}
-            {!comment.deletedAt && (
+            {!comment.deletedAt && comment.parentId === null && (
               <>
                 {replyParentId === comment.commentId ? (
                   <Form
@@ -197,7 +198,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
                       </Button>
                     </div>
                   </Form>
-                ) : (
+                ) : editingId !== comment.commentId ? (
                   <Button
                     variant="outline-secondary"
                     size="sm"
@@ -206,7 +207,8 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
                   >
                     답글
                   </Button>
-                )}
+                ) : null}
+
               </>
             )}
           </Card.Body>

--- a/frontend/src/pages/posts/PostDetailPage.jsx
+++ b/frontend/src/pages/posts/PostDetailPage.jsx
@@ -128,7 +128,7 @@ const PostDetailPage = () => {
                     myUserId={myUserId}
                     refreshPost={() => {
                       // 댓글 등록/수정/삭제 후, 게시글/댓글 전체 데이터를 새로 불러오는 함수
-                      window.location.reload();
+                      fetchPost();
                     }}
                   />
                 </div>

--- a/frontend/src/pages/posts/PostDetailPage.jsx
+++ b/frontend/src/pages/posts/PostDetailPage.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { Container, Card, Spinner, Alert, Button } from 'react-bootstrap';
 import base64 from 'base-64';
+import CommentSection from './CommentPage'; // 댓글 컴포넌트 임포트
 
 const PostDetailPage = () => {
   const { id } = useParams();
@@ -75,6 +76,7 @@ const PostDetailPage = () => {
   // 내 userId와 게시글 userId 비교
   const isOwner = post && myUserId && String(post.userId) === String(myUserId);
 
+
   return (
     <Container className="mt-4">
       <Button variant="outline-secondary" onClick={handleBack} className="mb-3">
@@ -119,6 +121,17 @@ const PostDetailPage = () => {
                 <Card.Text style={{ whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
                   {post.content}
                 </Card.Text>
+                <div className="mt-5">
+                  <CommentSection
+                    postId={post.id}
+                    comments={post.comments}
+                    myUserId={myUserId}
+                    refreshPost={() => {
+                      // 댓글 등록/수정/삭제 후, 게시글/댓글 전체 데이터를 새로 불러오는 함수
+                      window.location.reload();
+                    }}
+                  />
+                </div>
               </Card.Body>
               <Card.Footer className="bg-white border-0 text-end">
                 {/* 소유자만 수정/삭제 버튼 노출 */}


### PR DESCRIPTION
댓글/대댓글 CRUD API와 화면 만들기
대댓글은 1-depth까지만 허용
closed #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글에 댓글 기능이 추가되었습니다. 댓글 작성, 수정, 삭제, 답글(대댓글) 작성이 가능합니다.
  * 댓글은 트리 구조로 표시되며, 삭제된 댓글은 별도 표시됩니다.
  * 댓글 작성, 수정, 삭제 시 본인만 가능하며, 입력값 검증 및 권한 체크가 적용됩니다.
  * 게시글 상세 조회 시 댓글 트리 구조가 포함되어 표시됩니다.
  * 프론트엔드에 댓글 UI 컴포넌트가 추가되어 댓글 관리가 가능해졌습니다.

* **버그 수정**
  * 댓글, 게시글, 사용자 관련 예외 메시지 및 상태 코드가 명확하게 처리됩니다.

* **테스트**
  * 댓글 기능 전반(생성, 수정, 삭제, 예외 상황 등)에 대한 단위 및 통합 테스트가 추가되었습니다.
  * 테스트 환경에서 일관된 시간 처리를 위한 Clock 설정이 도입되었습니다.

* **문서화/스타일**
  * 일부 테스트 및 코드의 주석, 네이밍, 불필요 코드가 정리되었습니다.

* **환경설정/기타**
  * 더미 데이터 자동 생성 기능이 추가되어 개발 환경에서 테스트 데이터가 자동으로 생성됩니다.
  * 프론트엔드에 댓글 관련 라이브러리(base-64)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->