### PR TITLE
Feat#15 prometheus,k6

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: grafana/grafana:latest
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "3001:3000"
     networks:
       - monitoring-network
   k6:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  promethus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring-network
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - monitoring-network
+networks:
+    monitoring-network:
+        driver: bridge

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,6 +18,13 @@ services:
       - "3000:3000"
     networks:
       - monitoring-network
+  k6:
+    image: grafana/k6
+    volumes:
+      - ./scripts:/scripts
+    entrypoint: ""
+    command: ["k6", "run", "/scripts/myscript.js"]
+
 networks:
     monitoring-network:
         driver: bridge

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/backend/scripts/myscript.js
+++ b/backend/scripts/myscript.js
@@ -1,0 +1,39 @@
+import  http from 'k6/http';
+import { check } from 'k6';
+
+function getRandomPageId(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export let options = {
+    scenarios: {
+        constant_request_rate: {
+            executor: 'ramping-arrival-rate',
+            startRate: 167, // 초당 약 167개의 요청으로 시작
+            timeUnit: '1s',
+            preAllocatedVus: 50, // 사전 할당된 VU 수
+            maxVUs: 100, // 최대 VU 수
+            stages: [
+                { duration: '1m', target: 167},
+            ]
+        }
+    }
+}
+
+export default function () {
+    const pageId = getRandomPageId(1, 100);
+    const payload = JSON.stringify({
+        userId: pageId
+    });
+    const params = {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    };
+
+    let response = http.get('http://host.docker.internal:8080/api/posts/' + pageId, payload, params);
+
+    check(response, {
+        'status is 204': (r) => r.status === 204,
+    })
+}

--- a/backend/scripts/myscript.js
+++ b/backend/scripts/myscript.js
@@ -21,7 +21,7 @@ export let options = {
 }
 
 export default function () {
-    const pageId = getRandomPageId(1, 100);
+    const pageId = getRandomPageId(0,1);
     const payload = JSON.stringify({
         userId: pageId
     });
@@ -34,6 +34,6 @@ export default function () {
     let response = http.get('http://host.docker.internal:8080/api/posts/' + pageId, payload, params);
 
     check(response, {
-        'status is 204': (r) => r.status === 204,
+        'status is 200': (r) => r.status === 200,
     })
 }

--- a/backend/scripts/myscript.js
+++ b/backend/scripts/myscript.js
@@ -22,16 +22,13 @@ export let options = {
 
 export default function () {
     const pageId = getRandomPageId(0,1);
-    const payload = JSON.stringify({
-        userId: pageId
-    });
     const params = {
         headers: {
             'Content-Type': 'application/json',
         },
     };
 
-    let response = http.get('http://host.docker.internal:8080/api/posts/' + pageId, payload, params);
+    let response = http.get('http://host.docker.internal:8080/api/posts/' + pageId, params);
 
     check(response, {
         'status is 200': (r) => r.status === 200,

--- a/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
@@ -76,7 +76,8 @@ public class SecurityConfig {
 		//경로별 인가 작업
 		http
 			.authorizeHttpRequests((auth) -> auth
-				.requestMatchers("/api/auth/login", "/", "/api/auth/signup","/swagger-ui/**","/v3/api-docs/**","/api/posts/details/**").permitAll()
+				.requestMatchers("/api/auth/login", "/", "/api/auth/signup","/swagger-ui/**","/v3/api-docs/**",
+					"/api/posts/details/**", "/actuator/**").permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 

--- a/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -78,6 +79,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests((auth) -> auth
 				.requestMatchers("/api/auth/login", "/", "/api/auth/signup","/swagger-ui/**","/v3/api-docs/**",
 					"/api/posts/details/**", "/actuator/**").permitAll()
+				.requestMatchers(RegexRequestMatcher.regexMatcher("/api/posts/\\d+")).permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 

--- a/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/juniortown/backend/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests((auth) -> auth
 				.requestMatchers("/api/auth/login", "/", "/api/auth/signup","/swagger-ui/**","/v3/api-docs/**",
-					"/api/posts/details/**", "/actuator/**").permitAll()
+					"/api/posts/details/**", "/actuator/health","/actuator/prometheus").permitAll()
 				.requestMatchers(RegexRequestMatcher.regexMatcher("/api/posts/\\d+")).permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());

--- a/backend/src/main/java/org/juniortown/backend/interceptor/GuestCookieInterceptor.java
+++ b/backend/src/main/java/org/juniortown/backend/interceptor/GuestCookieInterceptor.java
@@ -30,6 +30,7 @@ public class GuestCookieInterceptor implements HandlerInterceptor {
 			cookie.setPath("/");
 			cookie.setMaxAge(60 * 60 * 24 * 15); // 15 days
 			cookie.setHttpOnly(true);
+			request.setAttribute(COOKIE_NAME, guestId);
 			response.addCookie(cookie);
 		}
 		return true;

--- a/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
+++ b/backend/src/main/java/org/juniortown/backend/post/controller/PostController.java
@@ -61,10 +61,10 @@ public class PostController {
 
 	// 게시글 목록 조회, 페이지네이션 적용
 	@GetMapping("/posts/{page}")
-	public ResponseEntity<PageResponse<PostResponse>> getPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable int page) {
-		Long userId = customUserDetails.getUserId();
-		// null체크
-
+	public ResponseEntity<PageResponse<PostResponse>> getPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable int page
+	) {
+		Long userId = (customUserDetails != null) ? customUserDetails.getUserId() : null;
 	 	Page<PostResponse> posts = postService.getPosts(userId, page);
 		PageResponse<PostResponse> response = new PageResponse<>(posts);
 		return ResponseEntity.ok(response);

--- a/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
@@ -31,7 +31,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
 	@Query(
 		"SELECT p.id AS id, p.title AS title, p.readCount AS readCount, u.name AS username, u.id AS userId, COUNT(l.id) AS likeCount, " +
-			"p.createdAt AS createdAt, p.updatedAt AS updatedAt " +
+			"p.createdAt AS createdAt, p.updatedAt AS updatedAt, false AS isLiked " +
 			"FROM Post p " +
 			"JOIN p.user u " +
 			"LEFT JOIN Like l ON l.post.id = p.id " +

--- a/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/org/juniortown/backend/post/repository/PostRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.Index;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 	Page<Post> findAllByDeletedAtIsNull(Pageable pageable);
@@ -25,5 +27,16 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 			"WHERE p.deletedAt IS NULL " +
 			"GROUP BY p.id, p.title, p.readCount, u.name, u.id, p.createdAt, p.updatedAt, p.deletedAt"
 	)
-	Page<PostWithLikeCountProjection> findAllWithLikeCount(@Param("userId") Long userId, Pageable pageable);
+	Page<PostWithLikeCountProjection> findAllWithLikeCountForUser(@Param("userId") Long userId, Pageable pageable);
+
+	@Query(
+		"SELECT p.id AS id, p.title AS title, p.readCount AS readCount, u.name AS username, u.id AS userId, COUNT(l.id) AS likeCount, " +
+			"p.createdAt AS createdAt, p.updatedAt AS updatedAt " +
+			"FROM Post p " +
+			"JOIN p.user u " +
+			"LEFT JOIN Like l ON l.post.id = p.id " +
+			"WHERE p.deletedAt IS NULL " +
+			"GROUP BY p.id, p.title, p.readCount, u.name, u.id, p.createdAt, p.updatedAt, p.deletedAt"
+	)
+	Page<PostWithLikeCountProjection> findAllWithLikeCountForNonUser(Pageable pageable);
 }

--- a/backend/src/main/java/org/juniortown/backend/user/dto/CustomUserDetails.java
+++ b/backend/src/main/java/org/juniortown/backend/user/dto/CustomUserDetails.java
@@ -33,8 +33,10 @@ public class CustomUserDetails implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return user.getEmail();
+		return user.getName();
 	}
+
+	public String getUserEmail() {return user.getEmail();}
 
 	public Long getUserId() {
 		return user.getId();

--- a/backend/src/main/java/org/juniortown/backend/user/jwt/JWTFilter.java
+++ b/backend/src/main/java/org/juniortown/backend/user/jwt/JWTFilter.java
@@ -40,15 +40,17 @@ public class JWTFilter extends OncePerRequestFilter {
 			filterChain.doFilter(request, response);
 			return;
 		}
-
+		String email = jwtUtil.getUserEmail(token);
 		String username = jwtUtil.getUsername(token);
 		String role = jwtUtil.getRole(token);
 		Long userId = jwtUtil.getUserId(token);
 
+
 		//userEntity를 생성하여 값 set
 		User user = User.builder()
 			.id(userId)
-			.email(username)
+			.email(email)
+			.name(username)
 			.role(role)
 			.build();
 

--- a/backend/src/main/java/org/juniortown/backend/user/jwt/JWTUtil.java
+++ b/backend/src/main/java/org/juniortown/backend/user/jwt/JWTUtil.java
@@ -15,6 +15,10 @@ import io.jsonwebtoken.Jwts;
 public class JWTUtil {
 
 	private final SecretKey secretKey;
+	private static final String CLAIM_USER_ID = "userId";
+	private static final String CLAIM_EMAIL = "email";
+	private static final String CLAIM_USERNAME = "username";
+	private static final String CLAIM_ROLE = "role";
 
 	public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
 		secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
@@ -42,10 +46,10 @@ public class JWTUtil {
 	public String createJwt(Long id, String email, String username, String role, Long expiredMs) {
 
 		return Jwts.builder()
-			.claim("userId", id)
-			.claim("email", email)
-			.claim("username", username)
-			.claim("role", role)
+			.claim(CLAIM_USER_ID, id)
+			.claim(CLAIM_EMAIL, email)
+			.claim(CLAIM_USERNAME, username)
+			.claim(CLAIM_ROLE, role)
 			.issuedAt(new Date(System.currentTimeMillis()))
 			.expiration(new Date(System.currentTimeMillis() + expiredMs))
 			.signWith(secretKey)

--- a/backend/src/main/java/org/juniortown/backend/user/jwt/JWTUtil.java
+++ b/backend/src/main/java/org/juniortown/backend/user/jwt/JWTUtil.java
@@ -21,6 +21,10 @@ public class JWTUtil {
 	}
 
 	public String getUsername(String token) {
+		return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+	}
+
+	public String getUserEmail(String token) {
 		return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
 	}
 
@@ -35,11 +39,12 @@ public class JWTUtil {
 		return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
 	}
 
-	public String createJwt(Long id, String email, String role, Long expiredMs) {
+	public String createJwt(Long id, String email, String username, String role, Long expiredMs) {
 
 		return Jwts.builder()
 			.claim("userId", id)
 			.claim("email", email)
+			.claim("username", username)
 			.claim("role", role)
 			.issuedAt(new Date(System.currentTimeMillis()))
 			.expiration(new Date(System.currentTimeMillis() + expiredMs))

--- a/backend/src/main/java/org/juniortown/backend/user/jwt/LoginFilter.java
+++ b/backend/src/main/java/org/juniortown/backend/user/jwt/LoginFilter.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import org.juniortown.backend.user.dto.CustomUserDetails;
 import org.juniortown.backend.user.dto.LoginDTO;
 import org.juniortown.backend.user.response.LoginResultDTO;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -48,6 +47,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 	@Override
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
 		CustomUserDetails customUserDetails = (CustomUserDetails)authentication.getPrincipal();
+		String userEmail = customUserDetails.getUserEmail();
 		String username = customUserDetails.getUsername();
 		Long userId = customUserDetails.getUserId();
 
@@ -57,7 +57,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
 		String role = auth.getAuthority();
 
-		String token = jwtUtil.createJwt(userId, username, role, 1000 * 60 * 60 * 24L ); // 24시간 유효한 토큰 생성
+		String token = jwtUtil.createJwt(userId, userEmail, username, role, 1000 * 60 * 60 * 24L ); // 24시간 유효한 토큰 생성
 
 		response.addHeader("Authorization", "Bearer " + token);
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,8 +33,7 @@ management:
   endpoints:
     web:
       exposure:
-        include:
-          "*"
+        include: ["health", "prometheus"]
   endpoint:
     health:
       show-details: always

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -29,6 +29,16 @@ spring:
   jwt:
     secret: ${JWT_SECRET_KEY}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          "*"
+  endpoint:
+    health:
+      show-details: always
+
 
 
 

--- a/backend/src/test/java/org/juniortown/backend/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/comment/service/CommentServiceTest.java
@@ -280,16 +280,14 @@ class CommentServiceTest {
 			.build();
 
 
-
-
 		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 		when(postRepository.findById(POST_ID)).thenReturn(Optional.of(post));
 		when(commentRepository.findById(parentId)).thenReturn(Optional.empty());
 
 		// when, then
 		Assertions.assertThatThrownBy(() -> commentService.createComment(USER_ID, commentCreateRequest))
-			.isInstanceOf(CircularReferenceException.class)
-			.hasMessage(CircularReferenceException.MESSAGE);
+			.isInstanceOf(CommentNotFoundException.class)
+			.hasMessage(CommentNotFoundException.MESSAGE);
 		verify(commentRepository, never()).save(any(Comment.class));
 	}
 	@Test

--- a/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/AuthControllerTest.java
@@ -198,7 +198,7 @@ class AuthControllerTest {
 
 		// Authorization 헤더에서 JWT 토큰을 추출하고 검증
 		String Token = mvcResult.getResponse().getHeader("Authorization");
-		String extractedUsername = jwtUtil.getUsername(Token.split(" ")[1]);
+		String extractedUsername = jwtUtil.getUserEmail(Token.split(" ")[1]);
 		Assertions.assertEquals("init@gmail.com", extractedUsername);
 		Assertions.assertFalse(jwtUtil.isExpired(Token.split(" ")[1]));
 

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.juniortown.backend.config.RedisTestConfig;
-import org.juniortown.backend.config.SyncConfig;
-import org.juniortown.backend.config.TestClockConfig;
 import org.juniortown.backend.config.TestClockNotMockConfig;
 import org.juniortown.backend.like.entity.Like;
 import org.juniortown.backend.like.repository.LikeRepository;
@@ -24,13 +22,9 @@ import org.juniortown.backend.user.jwt.JWTUtil;
 import org.juniortown.backend.user.repository.UserRepository;
 import org.juniortown.backend.user.request.SignUpDTO;
 import org.juniortown.backend.user.service.AuthService;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,7 +41,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redis.testcontainers.RedisContainer;
 

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerPagingTest.java
@@ -54,7 +54,7 @@ import com.redis.testcontainers.RedisContainer;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import({RedisTestConfig.class, SyncConfig.class, TestClockNotMockConfig.class})
+@Import({RedisTestConfig.class, TestClockNotMockConfig.class})
 @Transactional
 @Testcontainers
 public class PostControllerPagingTest {
@@ -322,4 +322,31 @@ public class PostControllerPagingTest {
 			.andExpect(jsonPath("$.page").value(0)) // 현재 페이지
 			.andDo(print());
 	}
+
+	@Test
+	@DisplayName("글 목록 조회 - 첫 페이지 조회 성공(비회원)")
+	void get_posts_first_page_success_with_non_user() throws Exception {
+		// given
+		int page = 0; // 첫 페이지
+
+		// expected
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/posts/{page}", page))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content", hasSize(10))) // 첫 페이지는 10개
+			.andExpect(jsonPath("$.totalElements").value(POST_COUNT)) // 전체 게시글 수
+			.andExpect(jsonPath("$.totalPages").value(6)) // 총 페이지 수
+			.andExpect(jsonPath("$.hasPrevious").value(false))
+			.andExpect(jsonPath("$.hasNext").value(true)) // 다음 페이지 있음
+			.andExpect(jsonPath("$.page").value(0)) // 현재 페이지
+			.andExpect(jsonPath("$.content[0].title").value("테스트 글 53")) // 첫 번째 게시글 제목
+			.andExpect(jsonPath("$.content[0].userId").value(testUser1.getId())) // 첫 번째 게시글 작성자 ID
+			.andExpect(jsonPath("$.content[0].userName").value(testUser1.getName())) // 첫 번째 게시글 작성자 이름
+			.andExpect(jsonPath("$.content[0].likeCount").value(0)) // 첫 번째 게시글 좋아요 수
+			.andExpect(jsonPath("$.content[0].readCount").value(0)) // 첫 번째 게시글 조회수
+			.andExpect(jsonPath("$.content[0].createdAt").exists()) // 첫 번째 게시글 생성일시
+			.andExpect(jsonPath("$.content[0].updatedAt").exists()) // 첫 번째 게시글 수정일시
+			.andExpect(jsonPath("$.content[0].isLiked").value(false)) // 첫 번째 게시글 좋아요 여부
+			.andDo(print());
+	}
+
 }

--- a/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
+++ b/backend/src/test/java/org/juniortown/backend/controller/PostControllerTest.java
@@ -117,7 +117,7 @@ class PostControllerTest {
 
 		String json = objectMapper.writeValueAsString(request);
 
-		String ghostToken = jwtUtil.createJwt(100L, "test@gmail.com", "ROLE_USER", 1000L);
+		String ghostToken = jwtUtil.createJwt(100L, "test@gmail.com","doncham", "ROLE_USER", 1000L);
 
 		// expected
 		mockMvc.perform(MockMvcRequestBuilders.post("/api/posts")
@@ -262,7 +262,7 @@ class PostControllerTest {
 			.build();
 		User saveUser2 = userRepository.save(user2);
 
-		String jwt = "Bearer " + jwtUtil.createJwt(saveUser2.getId(), saveUser2.getEmail(), saveUser2.getRole(), 10000L);
+		String jwt = "Bearer " + jwtUtil.createJwt(saveUser2.getId(), saveUser2.getEmail(),"doncham", saveUser2.getRole(), 10000L);
 
 		// Forbidden: 403
 		mockMvc.perform(MockMvcRequestBuilders.delete("/api/posts/{postId}", postId)
@@ -350,7 +350,7 @@ class PostControllerTest {
 			.build();
 		User saveUser2 = userRepository.save(user2);
 
-		String jwt = "Bearer " + jwtUtil.createJwt(saveUser2.getId(), saveUser2.getEmail(), saveUser2.getRole(), 10000L);
+		String jwt = "Bearer " + jwtUtil.createJwt(saveUser2.getId(), saveUser2.getEmail(),"doncham", saveUser2.getRole(), 10000L);
 
 		PostEdit postEdit = PostEdit.builder()
 			.title("수정된 제목")

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -207,7 +207,7 @@ class PostServiceTest {
 	void getPosts_returnsMappedPage() {
 		// given
 		int page = 0;
-		Sort sort = Sort.by("createdAt").descending();
+		Sort sort = Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id"));
 		PageRequest expectedPageable = PageRequest.of(page, PAGE_SIZE, sort);
 
 		PostWithLikeCountProjection post1 = mock(PostWithLikeCountProjection.class);
@@ -220,13 +220,53 @@ class PostServiceTest {
 		List<PostWithLikeCountProjection> projections = List.of(post1, post2);
 		PageImpl<PostWithLikeCountProjection> mockPage = new PageImpl<>(projections, expectedPageable, totalElements);
 		when(user.getId()).thenReturn(1L);
-		when(postRepository.findAllWithLikeCount(user.getId(), expectedPageable)).thenReturn(mockPage);
+		when(postRepository.findAllWithLikeCountForUser(user.getId(), expectedPageable)).thenReturn(mockPage);
 		when(redisTemplate.opsForValue()).thenReturn(readCountValueOperations);
 		// when
 		Page<PostResponse> result = postService.getPosts(user.getId(), page);
 
 		// then
-		verify(postRepository).findAllWithLikeCount(user.getId(), expectedPageable);
+		verify(postRepository).findAllWithLikeCountForUser(user.getId(), expectedPageable);
+
+		assertThat(result.getTotalElements()).isEqualTo(2);
+		assertThat(result.getSize()).isEqualTo(PAGE_SIZE);
+		assertThat(result.getTotalPages()).isEqualTo(1);
+		// 현재 페이지 번호
+		assertThat(result.getNumber()).isEqualTo(0);
+		// 현재 페이지에 들어있는 요소의 개수
+		assertThat(result.getNumberOfElements()).isEqualTo(2);
+
+		List<PostResponse> content = result.getContent();
+		assertThat(content).hasSize(2);
+		assertThat(content.get(0).getTitle()).isEqualTo("TA");
+		assertThat(content.get(1).getTitle()).isEqualTo("TB");
+	}
+
+	@Test
+	@DisplayName("비회원 게시글 페이지 조회 성공")
+	void getPosts_with_non_user() {
+		// given
+		int page = 0;
+		Sort sort = Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id"));
+		PageRequest expectedPageable = PageRequest.of(page, PAGE_SIZE, sort);
+
+		PostWithLikeCountProjection post1 = mock(PostWithLikeCountProjection.class);
+		when(post1.getTitle()).thenReturn("TA");
+		PostWithLikeCountProjection post2 = mock(PostWithLikeCountProjection.class);
+		when(post2.getTitle()).thenReturn("TB");
+
+		int totalElements = 2;
+
+		List<PostWithLikeCountProjection> projections = List.of(post1, post2);
+		PageImpl<PostWithLikeCountProjection> mockPage = new PageImpl<>(projections, expectedPageable, totalElements);
+		when(user.getId()).thenReturn(null);
+		when(postRepository.findAllWithLikeCountForNonUser(expectedPageable)).thenReturn(mockPage);
+		when(redisTemplate.opsForValue()).thenReturn(readCountValueOperations);
+		// when
+		Page<PostResponse> result = postService.getPosts(user.getId(), page);
+
+		// then
+		verify(postRepository).findAllWithLikeCountForNonUser(expectedPageable);
 
 		assertThat(result.getTotalElements()).isEqualTo(2);
 		assertThat(result.getSize()).isEqualTo(PAGE_SIZE);
@@ -247,11 +287,10 @@ class PostServiceTest {
 	void getPosts_emptyPage() {
 		//given
 		int page = 0;
-		PageRequest pageable = PageRequest.of(page, PAGE_SIZE, Sort.by("createdAt").descending());
+		PageRequest pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id")));
 		Page<PostWithLikeCountProjection> emptyPage = Page.empty(pageable);
 		when(user.getId()).thenReturn(1L);
-		when(postRepository.findAllWithLikeCount(user.getId(),pageable)).thenReturn(emptyPage);
-		when(redisTemplate.opsForValue()).thenReturn(readCountValueOperations);
+		when(postRepository.findAllWithLikeCountForUser(user.getId(),pageable)).thenReturn(emptyPage);
 
 		// when
 		Page<PostResponse> result = postService.getPosts(user.getId(), page);

--- a/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/org/juniortown/backend/post/service/PostServiceTest.java
@@ -259,11 +259,10 @@ class PostServiceTest {
 
 		List<PostWithLikeCountProjection> projections = List.of(post1, post2);
 		PageImpl<PostWithLikeCountProjection> mockPage = new PageImpl<>(projections, expectedPageable, totalElements);
-		when(user.getId()).thenReturn(null);
 		when(postRepository.findAllWithLikeCountForNonUser(expectedPageable)).thenReturn(mockPage);
 		when(redisTemplate.opsForValue()).thenReturn(readCountValueOperations);
 		// when
-		Page<PostResponse> result = postService.getPosts(user.getId(), page);
+		Page<PostResponse> result = postService.getPosts(null, page);
 
 		// then
 		verify(postRepository).findAllWithLikeCountForNonUser(expectedPageable);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,21 +8,25 @@ import PostListPage from './pages/posts/PostListPage'
 import Layout from './pages/components/Layout/Layout'
 import { SignUpPage } from './pages/users/SignUpPage'
 import { LoginPage } from './pages/users/LoginPage'
+import AuthProvider from './auth/AuthContext'
 
 const App = () => {
   return (
+    <AuthProvider>
       <Layout>
         <Routes>
           <Route path="/signup" element={<SignUpPage />} />
           <Route path='/login' element={<LoginPage />} />
           <Route path="/" element={<Home />} />
-          <Route path="/posts/add" element= {<PostCreatePage />} />
+          <Route path="/posts/add" element={<PostCreatePage />} />
           <Route path="/posts/edit/:id" element={<PostEditPage />} />
           <Route path="/posts/:id" element={<PostDetailsPage />} />
           <Route path="/posts" element={<PostListPage />} />
           <Route path="*" element={<Error />} />
         </Routes>
       </Layout>
+    </AuthProvider>
+
   )
 }
 export default App

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
+import axios from 'axios';
+
+const AuthContext = createContext(null);
+const STORAGE_KEY = 'jwt';
+
+// Base64URL → JSON 파싱
+function parseJwt(token) {
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const json = decodeURIComponent(atob(base64).split('').map(c =>
+      '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    ).join(''));
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export default function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem(STORAGE_KEY));
+  const [user, setUser] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    const payload = saved ? parseJwt(saved) : null;
+    return payload ? { id: payload.userId, email: payload.email, username: payload.username } : null;
+  });
+  const [ready, setReady] = useState(false); // 초기 복원 완료 여부
+
+  // 앱 부팅 시 localStorage → 상태 복원
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem(STORAGE_KEY, token);
+      axios.defaults.headers.common['Authorization'] = token;
+      const payload = parseJwt(token);
+      setUser(payload
+        ? { id: payload.userId, email: payload.email, userRole: payload.userRole, username: payload.username ?? payload.name }
+        : null
+      );
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+      delete axios.defaults.headers.common['Authorization'];
+      setUser(null);
+    }
+    setReady(true);
+  }, [token]);
+
+  const login = useCallback((newToken) => setToken(newToken), []);
+  const logout = useCallback(() => setToken(null), []);
+
+  const value = useMemo(() => ({
+    token,
+    user,
+    isAuthenticated: !!token,
+    ready,
+    login,
+    logout,
+  }), [token, user, ready, login, logout]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => useContext(AuthContext);
+

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -23,7 +23,7 @@ export default function AuthProvider({ children }) {
   const [user, setUser] = useState(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     const payload = saved ? parseJwt(saved) : null;
-    return payload ? { id: payload.userId, email: payload.email, username: payload.username } : null;
+    return payload ? { id: payload.userId, email: payload.email, username: payload.username, userRole: payload.userRole } : null;
   });
   const [ready, setReady] = useState(false); // 초기 복원 완료 여부
 
@@ -34,7 +34,7 @@ export default function AuthProvider({ children }) {
       axios.defaults.headers.common['Authorization'] = token;
       const payload = parseJwt(token);
       setUser(payload
-        ? { id: payload.userId, email: payload.email, userRole: payload.userRole, username: payload.username ?? payload.name }
+        ? { id: payload.userId, email: payload.email, userRole: payload.userRole, username: payload.username ?? payload.username }
         : null
       );
     } else {

--- a/frontend/src/pages/components/Layout/Header.js
+++ b/frontend/src/pages/components/Layout/Header.js
@@ -1,18 +1,46 @@
 import React from 'react';
 import { Navbar, Container, Nav, Button } from 'react-bootstrap';
-
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../auth/AuthContext';
 export default function Header() {
+  const navigate = useNavigate();
+  const { user, isAuthenticated, ready, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
   return (
     <Navbar bg="primary" variant="dark" expand="lg" className="shadow-sm">
       <Container>
-        <Navbar.Brand href="/" className="fw-bold">
+        <Navbar.Brand as={Link} to="/" className="fw-bold">
           JuniorTown
         </Navbar.Brand>
         <Navbar.Toggle aria-controls="main-nav" />
         <Navbar.Collapse id="main-nav">
-          <Nav className="ms-auto">
-            <Nav.Link href="/signup">회원가입</Nav.Link>
-            <Nav.Link href="/login">로그인</Nav.Link>
+          <Nav className="ms-auto align-items-center">
+
+            {/* 로그인 안 된 경우 */}
+            {!isAuthenticated && (
+              <>
+                <Nav.Link as={Link} to="/signup">회원가입</Nav.Link>
+                <Nav.Link as={Link} to="/login">로그인</Nav.Link>
+              </>
+            )}
+
+            {/* 로그인 된 경우 */}
+            {isAuthenticated && (
+              <>
+                <span className="text-light me-2">
+                  {user?.username || '회원'}님 환영합니다!
+                </span>
+                <Button variant="outline-light" className="ms-2" onClick={handleLogout}>
+                  로그아웃
+                </Button>
+              </>
+            )}
+
             <Button variant="outline-light" className="ms-2">
               도움말
             </Button>

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -25,7 +25,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
         postId,
         content: commentContent,
         parentId: null,
-      }, { headers: { Authorization: token } });
+      });
       setCommentContent('');
       refreshPost(); // 게시글 및 댓글 데이터 새로고침
     } catch (err) {
@@ -43,7 +43,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
         postId,
         content: replyContent,
         parentId,
-      }, { headers: { Authorization: token } });
+      });
       setReplyContent('');
       setReplyParentId(null);
       refreshPost();
@@ -57,9 +57,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
   const handleDelete = async (commentId) => {
     if (!window.confirm('댓글을 삭제할까요?')) return;
     try {
-      await axios.delete(`/api/comments/${commentId}`, {
-        headers: { Authorization: token },
-      });
+      await axios.delete(`/api/comments/${commentId}`);
       refreshPost();
     } catch (err) {
       console.error('댓글 삭제 실패:', err);
@@ -74,7 +72,7 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
     try {
       await axios.patch(`/api/comments/${commentId}`, {
         content: editingContent,
-      }, { headers: { Authorization: token } });
+      });
       setEditingId(null);
       setEditingContent('');
       refreshPost();

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Form, Card } from 'react-bootstrap';
 import axios from 'axios';
+import { useAuth } from '../../auth/AuthContext'; // 인증 컨텍스트 임포트
 
 
 function CommentSection({ postId, comments, myUserId, refreshPost }) {
@@ -10,13 +11,12 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
   const [editingId, setEditingId] = useState(null); // 수정 중인 댓글 id
   const [editingContent, setEditingContent] = useState('');
   const [replyParentId, setReplyParentId] = useState(null); // 대댓글 입력창 표시용 parent id
-
+  const { token } = useAuth(); // 인증 토큰 가져오기
   // 댓글 등록
   const handleCommentSubmit = async (e) => {
     e.preventDefault();
     if (!commentContent.trim()) return;
     try {
-      const token = localStorage.getItem('jwt');
       await axios.post('/api/comments', {
         postId,
         content: commentContent,
@@ -35,7 +35,6 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
     e.preventDefault();
     if (!replyContent.trim()) return;
     try {
-      const token = localStorage.getItem('jwt');
       await axios.post('/api/comments', {
         postId,
         content: replyContent,
@@ -54,7 +53,6 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
   const handleDelete = async (commentId) => {
     if (!window.confirm('댓글을 삭제할까요?')) return;
     try {
-      const token = localStorage.getItem('jwt');
       await axios.delete(`/api/comments/${commentId}`, {
         headers: { Authorization: token },
       });
@@ -70,7 +68,6 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
     e.preventDefault();
     if (!editingContent.trim()) return;
     try {
-      const token = localStorage.getItem('jwt');
       await axios.patch(`/api/comments/${commentId}`, {
         content: editingContent,
       }, { headers: { Authorization: token } });

--- a/frontend/src/pages/posts/CommentPage.jsx
+++ b/frontend/src/pages/posts/CommentPage.jsx
@@ -15,6 +15,10 @@ function CommentSection({ postId, comments, myUserId, refreshPost }) {
   // 댓글 등록
   const handleCommentSubmit = async (e) => {
     e.preventDefault();
+    if (!token) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
     if (!commentContent.trim()) return;
     try {
       await axios.post('/api/comments', {

--- a/frontend/src/pages/posts/PostCreatePage.jsx
+++ b/frontend/src/pages/posts/PostCreatePage.jsx
@@ -23,9 +23,7 @@ const PostCreatePage = () => {
         return;
       }
       const response = await axios.post('/api/posts', postData, {
-        headers: {
-          'Authorization': `${token}`,
-        },
+
       });
 
       // const result = response.data;

--- a/frontend/src/pages/posts/PostCreatePage.jsx
+++ b/frontend/src/pages/posts/PostCreatePage.jsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from 'react-bootstrap';
 import axios from 'axios'; // axios를 import
+import { useAuth } from '../../auth/AuthContext.jsx'; // 인증 컨텍스트 임포트
 
 const PostCreatePage = () => {
   const navigate = useNavigate();
+  const { token } = useAuth(); // 인증 토큰 가져오기
 
   // ① 제목과 내용을 담을 상태 변수 선언
   const [title, setTitle] = useState('');
@@ -15,7 +17,6 @@ const PostCreatePage = () => {
     const postData = { title, content };
 
     try {
-      const token = localStorage.getItem('jwt');
       if (!token) {
         alert('로그인이 필요합니다.');
         navigate('/login', { replace: true });

--- a/frontend/src/pages/posts/PostDetailPage.jsx
+++ b/frontend/src/pages/posts/PostDetailPage.jsx
@@ -1,81 +1,156 @@
-import { useState, useEffect } from 'react';
+// src/pages/posts/PostDetailPage.jsx
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { Container, Card, Spinner, Alert, Button } from 'react-bootstrap';
-import base64 from 'base-64';
-import CommentSection from './CommentPage'; // 댓글 컴포넌트 임포트
+import CommentSection from './CommentPage';
+import { useAuth } from '../../auth/AuthContext';
+
+// --------- 미니 아이콘 컴포넌트 (가벼운 라인 스타일) ----------
+const EyeIcon = ({ size = 18, className }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    className={className}
+    style={{ verticalAlign: '-2px' }}
+  >
+    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" strokeWidth="1.8" />
+    <circle cx="12" cy="12" r="3" strokeWidth="1.8" />
+  </svg>
+);
+
+const LikeButton = ({ isLiked, count, busy, onClick }) => (
+  <Button
+    variant={isLiked ? 'danger' : 'outline-danger'}
+    disabled={busy}
+    onClick={onClick}
+    className="d-inline-flex align-items-center"
+    style={{
+      borderRadius: 999,
+      padding: '6px 12px',
+      fontWeight: 600,
+      transition: 'transform 120ms ease',
+      boxShadow: isLiked ? '0 2px 6px rgba(220,53,69,.25)' : 'none'
+    }}
+    aria-pressed={isLiked}
+    aria-label={isLiked ? '좋아요 취소' : '좋아요'}
+  >
+    <span
+      style={{
+        fontSize: 16,
+        marginRight: 8,
+        transform: isLiked ? 'scale(1.05)' : 'none',
+        transition: 'transform 120ms ease'
+      }}
+    >
+      {isLiked ? '❤️' : '🤍'}
+    </span>
+    <span style={{ minWidth: 28, textAlign: 'right' }}>
+      {Number(count ?? 0).toLocaleString()}
+    </span>
+  </Button>
+);
 
 const PostDetailPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const { user, token } = useAuth();
 
   const [post, setPost] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(true);      // 초기 로딩
   const [error, setError] = useState(null);
-  // 로그인 사용자 id 저장
-  const [myUserId, setMyUserId] = useState(null);
+  const [likeBusy, setLikeBusy] = useState(false);   // 좋아요 처리 중 잠금
 
-  // 게시글 조회 및 내 userId 파싱
+  const myUserId = useMemo(() => user?.id ?? null, [user]);
+
+  // 최신 요청만 반영하기 위한 ID
+  const lastLikeReqIdRef = useRef(0);
+
+  // 게시글 조회
+  const fetchPost = useCallback(async () => {
+    if (!post) setLoading(true);
+    setError(null);
+    try {
+      const res = await axios.get(`/api/posts/details/${id}`, {
+        headers: token ? { Authorization: token } : undefined,
+      });
+      setPost(res.data);
+    } catch (err) {
+      setError('해당 게시물을 불러오는 데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, [id, token]);
+
   useEffect(() => {
-    const fetchPost = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const token = localStorage.getItem('jwt');
-        // JWT 파싱 (try-catch로 에러 방어 추천)
-        try {
-          const payload = JSON.parse(base64.decode(token.split('.')[1]));
-          setMyUserId(payload.userId);
-        } catch (error) {
-          console.error('JWT 파싱 오류:', error);
-        }
-        let loginUserId = null;
-        if (token) {
-          const payload = JSON.parse(base64.decode(token.split('.')[1]));
-          loginUserId = payload.userId;
-          setMyUserId(loginUserId);
-        }
-        // GET /api/posts/details/{id}
-        const response = await axios.get(`/api/posts/details/${id}`, {
-          headers: {
-            'Authorization': `${token}`,
-          },
-        });
-        setPost(response.data);
-      } catch (err) {
-        setError('해당 게시물을 불러오는 데 실패했습니다.');
-      } finally {
-        setLoading(false);
-      }
-    };
     fetchPost();
-  }, [id]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchPost]);
 
   const handleBack = () => navigate(-1);
+  const handleEdit = () => navigate(`/posts/edit/${id}`);
 
-  // 게시글 수정 페이지로 이동
-  const handleEdit = () => {
-    navigate(`/posts/edit/${id}`);
-  };
-
-  // 게시글 삭제 (선택)
   const handleDelete = async () => {
     if (!window.confirm('정말 삭제하시겠습니까?')) return;
     try {
-      const token = localStorage.getItem('jwt');
       await axios.delete(`/api/posts/${id}`, {
-        headers: { 'Authorization': `${token}` },
+        headers: token ? { Authorization: token } : undefined,
       });
       alert('게시글이 삭제되었습니다.');
       navigate('/posts');
-    } catch (err) {
+    } catch {
       alert('게시물 삭제에 실패했습니다.');
     }
   };
 
-  // 내 userId와 게시글 userId 비교
-  const isOwner = post && myUserId && String(post.userId) === String(myUserId);
+  // 좋아요 토글 (낙관적 업데이트 + 중복 클릭 방지 + 최신 응답만 반영)
+  const handleLike = useCallback(async () => {
+    if (!token) {
+      alert('로그인이 필요합니다.');
+      navigate('/login', { replace: true });
+      return;
+    }
+    if (!post || likeBusy) return;
 
+    setLikeBusy(true);
+    const reqId = ++lastLikeReqIdRef.current;
+
+    const prevIsLiked = !!post.isLiked;
+    const prevCount = Number(post.likeCount ?? 0);
+
+    // 낙관적 반영
+    const nextIsLiked = !prevIsLiked;
+    const nextCount = nextIsLiked ? prevCount + 1 : Math.max(0, prevCount - 1);
+    setPost(p => (p ? { ...p, isLiked: nextIsLiked, likeCount: nextCount } : p));
+
+    try {
+      const res = await axios.post(`/api/posts/likes/${post.id}`, null, {
+        headers: { Authorization: token },
+      });
+      // 최신 요청만 반영
+      if (reqId === lastLikeReqIdRef.current) {
+        const serverIsLiked = !!res.data?.isLiked;
+        const fixedCount = serverIsLiked
+          ? (prevIsLiked ? prevCount : prevCount + 1)
+          : (prevIsLiked ? Math.max(0, prevCount - 1) : prevCount);
+
+        setPost(p => (p ? { ...p, isLiked: serverIsLiked, likeCount: fixedCount } : p));
+      }
+    } catch {
+      if (reqId === lastLikeReqIdRef.current) {
+        // 실패 롤백
+        setPost(p => (p ? { ...p, isLiked: prevIsLiked, likeCount: prevCount } : p));
+        alert('좋아요 처리에 실패했습니다.');
+      }
+    } finally {
+      if (reqId === lastLikeReqIdRef.current) setLikeBusy(false);
+    }
+  }, [post, token, navigate, likeBusy]);
+
+  const isOwner = post && myUserId && String(post.userId) === String(myUserId);
 
   return (
     <Container className="mt-4">
@@ -85,13 +160,11 @@ const PostDetailPage = () => {
 
       {loading && (
         <div className="d-flex justify-content-center my-5">
-          <Spinner animation="border" role="status">
-            <span className="visually-hidden">Loading...</span>
-          </Spinner>
+          <Spinner animation="border" role="status" />
         </div>
       )}
 
-      {error && (
+      {error && !loading && (
         <Alert variant="danger" className="my-3">
           {error}
         </Alert>
@@ -101,40 +174,72 @@ const PostDetailPage = () => {
         <>
           {post ? (
             <Card className="shadow-sm">
+              {/* ===== 헤더: 제목 / 메타 / 좋아요 버튼 ===== */}
               <Card.Header className="bg-white border-0">
-                <h4 className="mb-0">{post.title}</h4>
-                <small className="text-muted">
-                  작성일:{" "}
-                  {new Date(post.createdAt).toLocaleString("ko-KR", {
-                    year: "numeric",
-                    month: "2-digit",
-                    day: "2-digit",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </small>
-                <small className="text-muted ms-2">
-                  👁️ {post.readCount?.toLocaleString()}회
-                </small>
+                <div className="d-flex align-items-start justify-content-between gap-3">
+                  <div className="flex-grow-1">
+                    <h4 className="mb-2" style={{ wordBreak: 'keep-all' }}>
+                      {post.title}
+                    </h4>
+
+                    {/* 메타 라인: 작성일 / 조회수 */}
+                    <div className="d-flex flex-wrap align-items-center gap-1">
+                      <span
+                        className="badge rounded-pill text-bg-light"
+                        style={{ fontWeight: 500 }}
+                        title="작성일"
+                      >
+                        {new Date(post.createdAt).toLocaleString('ko-KR', {
+                          year: 'numeric',
+                          month: '2-digit',
+                          day: '2-digit',
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </span>
+
+                      <span className="text-muted">•</span>
+
+                      <span
+                        className="badge rounded-pill text-bg-light d-inline-flex align-items-center"
+                        style={{ gap: 6, fontWeight: 500 }}
+                        title="조회수"
+                      >
+                        <EyeIcon />
+                        {post.readCount?.toLocaleString()}회
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* 좋아요 버튼 */}
+                  <LikeButton
+                    isLiked={!!post.isLiked}
+                    count={post.likeCount}
+                    busy={likeBusy}
+                    onClick={handleLike}
+                  />
+                </div>
               </Card.Header>
+
+              {/* ===== 본문 ===== */}
               <Card.Body>
-                <Card.Text style={{ whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
+                <Card.Text style={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
                   {post.content}
                 </Card.Text>
+
+                {/* 댓글 섹션 */}
                 <div className="mt-5">
                   <CommentSection
                     postId={post.id}
                     comments={post.comments}
                     myUserId={myUserId}
-                    refreshPost={() => {
-                      // 댓글 등록/수정/삭제 후, 게시글/댓글 전체 데이터를 새로 불러오는 함수
-                      fetchPost();
-                    }}
+                    refreshPost={fetchPost}
                   />
                 </div>
               </Card.Body>
+
+              {/* ===== 푸터: 소유자 액션 ===== */}
               <Card.Footer className="bg-white border-0 text-end">
-                {/* 소유자만 수정/삭제 버튼 노출 */}
                 {isOwner ? (
                   <>
                     <Button variant="outline-primary" onClick={handleEdit} className="me-2">

--- a/frontend/src/pages/posts/PostDetailPage.jsx
+++ b/frontend/src/pages/posts/PostDetailPage.jsx
@@ -74,9 +74,7 @@ const PostDetailPage = () => {
     if (!post) setLoading(true);
     setError(null);
     try {
-      const res = await axios.get(`/api/posts/details/${id}`, {
-        headers: token ? { Authorization: token } : undefined,
-      });
+      const res = await axios.get(`/api/posts/details/${id}`);
       setPost(res.data);
     } catch (err) {
       setError('해당 게시물을 불러오는 데 실패했습니다.');
@@ -96,9 +94,7 @@ const PostDetailPage = () => {
   const handleDelete = async () => {
     if (!window.confirm('정말 삭제하시겠습니까?')) return;
     try {
-      await axios.delete(`/api/posts/${id}`, {
-        headers: token ? { Authorization: token } : undefined,
-      });
+      await axios.delete(`/api/posts/${id}`);
       alert('게시글이 삭제되었습니다.');
       navigate('/posts');
     } catch {
@@ -127,9 +123,7 @@ const PostDetailPage = () => {
     setPost(p => (p ? { ...p, isLiked: nextIsLiked, likeCount: nextCount } : p));
 
     try {
-      const res = await axios.post(`/api/posts/likes/${post.id}`, null, {
-        headers: { Authorization: token },
-      });
+      const res = await axios.post(`/api/posts/likes/${post.id}`);
       // 최신 요청만 반영
       if (reqId === lastLikeReqIdRef.current) {
         const serverIsLiked = !!res.data?.isLiked;

--- a/frontend/src/pages/posts/PostEditPage.jsx
+++ b/frontend/src/pages/posts/PostEditPage.jsx
@@ -24,11 +24,7 @@ const PostEditPage = () => {
   useEffect(() => {
     const fetchPost = async () => {
       try {
-        const response = await axios.get(`/api/posts/details/${id}`, {
-          headers: {
-            'Authorization': `${token}`,
-          },
-        });
+        const response = await axios.get(`/api/posts/details/${id}`);
         // 성공적으로 데이터를 받아오면 title과 content를 초기화
         setTitle(response.data.title);
         setContent(response.data.content);
@@ -60,11 +56,8 @@ const PostEditPage = () => {
       await axios.patch(`/api/posts/${id}`, {
         title,
         content,
-      }, {
-        headers: {
-          'Authorization': `${token}`,
-        },
-      });
+      },
+      );
       // 수정이 완료되면 상세 페이지로 이동
       navigate(`/posts/${id}`, { replace: true });
     } catch (err) {

--- a/frontend/src/pages/posts/PostEditPage.jsx
+++ b/frontend/src/pages/posts/PostEditPage.jsx
@@ -5,11 +5,13 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { Container, Form, Button, Spinner, Alert } from 'react-bootstrap';
 import base64 from 'base-64';
+import { useAuth } from '../../auth/AuthContext'; // 인증 컨텍스트 임포트
 
 const PostEditPage = () => {
   // 1. URL에서 id 파라미터를 추출
   const { id } = useParams();
   const navigate = useNavigate();
+  const { token } = useAuth(); // 인증 토큰 가져오기
 
   // 2. 컴포넌트 상태 정의
   const [title, setTitle] = useState('');       // 수정할 게시물의 제목
@@ -22,8 +24,6 @@ const PostEditPage = () => {
   useEffect(() => {
     const fetchPost = async () => {
       try {
-        const token = localStorage.getItem('jwt');
-      
         const response = await axios.get(`/api/posts/details/${id}`, {
           headers: {
             'Authorization': `${token}`,
@@ -49,8 +49,6 @@ const PostEditPage = () => {
     setSaving(true);
     setError(null);
 
-    const token = localStorage.getItem('jwt');
-
     if (!token) {
       alert('로그인이 필요합니다.');
       navigate('/login', { replace: true });
@@ -58,7 +56,7 @@ const PostEditPage = () => {
     }
     try {
       // PUT /api/posts/{id}로 수정 요청
-  
+
       await axios.patch(`/api/posts/${id}`, {
         title,
         content,

--- a/frontend/src/pages/posts/PostListPage.jsx
+++ b/frontend/src/pages/posts/PostListPage.jsx
@@ -29,11 +29,7 @@ const PostListPage = () => {
         //   return; // Stop fetching posts if not logged in
         // }
         //서버가 쿼리 파라미터로 page를 받는 걸 권장
-        const response = await axios.get(`/api/posts/${page}`, {
-          headers: {
-            'Authorization': `${token}`,
-          },
-        });
+        const response = await axios.get(`/api/posts/${page}`);
 
         setPosts(response.data.content);
         setTotalPages(response.data.totalPages);

--- a/frontend/src/pages/posts/PostListPage.jsx
+++ b/frontend/src/pages/posts/PostListPage.jsx
@@ -23,12 +23,12 @@ const PostListPage = () => {
       setLoading(true);
       setError(null);
       try {
-        if (!token) {
-          alert('로그인이 필요합니다.');
-          navigate('/login', { replace: true });
-          return; // Stop fetching posts if not logged in
-        }
-        // 서버가 쿼리 파라미터로 page를 받는 걸 권장
+        // if (!token) {
+        //   alert('로그인이 필요합니다.');
+        //   navigate('/login', { replace: true });
+        //   return; // Stop fetching posts if not logged in
+        // }
+        //서버가 쿼리 파라미터로 page를 받는 걸 권장
         const response = await axios.get(`/api/posts/${page}`, {
           headers: {
             'Authorization': `${token}`,
@@ -38,6 +38,7 @@ const PostListPage = () => {
         setPosts(response.data.content);
         setTotalPages(response.data.totalPages);
       } catch (err) {
+        console.error('게시물 목록 조회 실패:', err);
         setError('게시물 목록을 가져오지 못했습니다.');
       } finally {
         setLoading(false);

--- a/frontend/src/pages/posts/PostListPage.jsx
+++ b/frontend/src/pages/posts/PostListPage.jsx
@@ -3,11 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { Container, Table, Spinner, Alert, Button } from 'react-bootstrap';
 import Pagination from 'react-bootstrap/Pagination';
-
+import { useAuth } from '../../auth/AuthContext'; // 인증 컨텍스트 임포트
 const GROUP_SIZE = 10;
 
 const PostListPage = () => {
   const navigate = useNavigate();
+  const { token } = useAuth(); // 인증 토큰 가져오기
 
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -22,7 +23,6 @@ const PostListPage = () => {
       setLoading(true);
       setError(null);
       try {
-        const token = localStorage.getItem('jwt');
         if (!token) {
           alert('로그인이 필요합니다.');
           navigate('/login', { replace: true });
@@ -65,37 +65,6 @@ const PostListPage = () => {
     );
   }
 
-  const handleLike = async (postId, currentIsLiked, currentLikeCount) => {
-    const token = localStorage.getItem('jwt');
-    if (!token) {
-      alert('로그인이 필요합니다.');
-      navigate('/login', { replace: true });
-      return; // Stop if not logged in
-    }
-    try {
-      const response = await axios.post(`/api/posts/likes/${postId}`, null, {
-        headers: { 'Authorization': `${token}` },
-      });
-      const { isLiked } = response.data;
-
-      // posts 배열에서 해당 post의 isLiked, likeCount 업데이트
-      setPosts((prevPosts) =>
-        prevPosts.map((post) =>
-          post.id === postId
-            ? {
-              ...post,
-              isLiked: isLiked,
-              likeCount: isLiked
-                ? currentLikeCount + 1
-                : Math.max(0, currentLikeCount - 1),
-            }
-            : post
-        )
-      );
-    } catch (err) {
-      alert('좋아요 처리에 실패했습니다.');
-    }
-  };
 
   return (
     <Container className="mt-4">
@@ -167,7 +136,6 @@ const PostListPage = () => {
                           color: post.isLiked ? '#dc3545' : '#adb5bd',
                         }}
                         aria-label={post.isLiked ? '좋아요 취소' : '좋아요'}
-                        onClick={() => handleLike(post.id, post.isLiked, post.likeCount)}
                       >
                         {post.isLiked ? '❤️' : '🤍'}
                       </button>

--- a/frontend/src/pages/users/LoginPage.jsx
+++ b/frontend/src/pages/users/LoginPage.jsx
@@ -1,10 +1,12 @@
-import axios from 'axios';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { useAuth } from '../../auth/AuthContext.jsx'
 
 export function LoginPage() {
   const [credentials, setCredentials] = useState({ email: '', password: '' });
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const handleChange = (e) => {
     setCredentials({
@@ -19,9 +21,9 @@ export function LoginPage() {
     axios.post('/api/auth/login', credentials)
       .then(res => {
         const token = res.headers['authorization'];
-        localStorage.setItem('jwt', token); 
+        localStorage.setItem('jwt', token);
         axios.defaults.headers.common['Authorization'] = token;
-
+        login(token);
         alert('로그인에 성공했습니다.');
         // 로그인 성공 후 홈 페이지로 리다이렉트
         navigate('/', { replace: true });

--- a/frontend/src/pages/users/LoginPage.jsx
+++ b/frontend/src/pages/users/LoginPage.jsx
@@ -21,8 +21,9 @@ export function LoginPage() {
     axios.post('/api/auth/login', credentials)
       .then(res => {
         const token = res.headers['authorization'];
-        localStorage.setItem('jwt', token);
-        axios.defaults.headers.common['Authorization'] = token;
+        if (!token) {
+          throw new Error('토큰이 없습니다.');
+        }
         login(token);
         alert('로그인에 성공했습니다.');
         // 로그인 성공 후 홈 페이지로 리다이렉트


### PR DESCRIPTION
1.프로메테우스,그라파나,k6 적용
근데 k6로 부하테스트 하려다보니 부하 생성기와 서버를 분리할 필요를 느껴서 프로젝트 완성도를 좀 더 높혀서 aws에 배포 후 부하테스트 및 쿼리 튜닝을 진행하기로 함.
2.비회원을 위한 게시글 목록 조회 구현
3.게시글 목록에서 좋아요 클릭 기능 삭제
4.게시글 상세 조회에서 좋아요 클릭 로직 적용.
5.프론트에서 JWT 관리를 위해 useContext 학습 후 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 시스템 모니터링 활성화: 헬스/메트릭 엔드포인트 공개 및 로컬 Prometheus·Grafana·k6 실행 지원
  - 전역 인증 컨텍스트 도입: 로그인 상태 관리, 헤더에서 사용자 인사·로그아웃 제공
  - 게시글 상세에 좋아요 버튼 추가(낙관적 업데이트 및 중복 요청 방지)
  - 비로그인 사용자의 게시글 목록 조회 지원 개선
  - 로그인 토큰에 사용자 정보 확장(클라이언트 표시 개선)
- Bug Fixes
  - 인증 정보 부재 시 발생하던 조회 오류(NPE 등) 예방
- Chores
  - 부하 테스트 스크립트 및 모니터링 구성 추가 (Docker Compose 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->